### PR TITLE
Update weather.py

### DIFF
--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -20,12 +20,12 @@ class Weather(IntervalModule):
 
     settings = (
         "location_code",
-        ("units", "Celsius (C) or Fahrenheit (F)"),
+        ("units", "Celsius (metric) or Fahrenheit (imperial)"),
         "format",
     )
     required = ("location_code",)
 
-    units = "C"
+    units = "metric"
     format = "{current_temp}"
 
     @require(internet)


### PR DESCRIPTION
The current settings indicate that if you use units="F" as one of the arguments, you will get the appropriate response. However, the pywapi requires units="imperial" to get it to work, and to be consistent I changed units="metric".

The text also isn't clear how to get the location codes, there are a few ways to do that, I'm open to mentioning that if there is interest.
