### PR TITLE
Optionally skip MAC address check in network

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -74,7 +74,6 @@ class Network(IntervalModule):
         "format_down", "color_down",
         ("detached_down", "If the interface doesn't exist, display it as if it were down"),
         "name",
-        ("mac", "Try and fetch the interface MAC address, default True")
     )
 
     name = interface = "eth0"
@@ -83,8 +82,6 @@ class Network(IntervalModule):
     color_up = "#00FF00"
     color_down = "#FF0000"
     detached_down = False
-    mac = True
-
 
     def init(self):
         if self.interface not in netifaces.interfaces() and not self.detached_down:
@@ -101,14 +98,16 @@ class Network(IntervalModule):
         up = netifaces.AF_INET in info or netifaces.AF_INET6 in info
         fdict = dict(
             zip_longest(["v4", "v4mask", "v4cidr", "v6", "v6mask", "v6cidr"], [], fillvalue=""))
+
+        try:
+            mac = info[netifaces.AF_PACKET][0]["addr"]
+        except KeyError:
+            mac = "NONE"
         fdict.update({
             "interface": self.interface,
             "name": self.name,
+            "mac": mac,
         })
-        if self.mac:
-            fdict["mac"] = info[netifaces.AF_PACKET][0]["addr"]
-        else:
-            fdict["mac"] = "NONE"
 
         if up:
             format = self.format_up


### PR DESCRIPTION
Network interfaces don't necessarily have a MAC address. For example,
the tunnel devices created by OpenVPN do not. Previously, passing a
network interface that did not have a MAC address caused the network
module to fail, since it assumed that there would be one.

This commit just adds a flag to the network module "mac", which defaults
to True. If True, the module behaves like before. If False, the check
for the MAC address is skipped and the {mac} format variable is replaced
with "NONE".

I tested this with my OpenVPN interface as well as my regular interface
and it works fine.
