### PR TITLE
clock: allow to specify a custom color and/or to use i3bar default color

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -351,6 +351,7 @@ This class shows a clock
 Settings:
 
 :format: stftime format string, `None` means to use the default, locale-dependent format (default: ``None``)
+:color: RGB hexadecimal code color specifier, set to `i3Bar` to use i3 bar default (default: ``#ffffff``)
 :interval:  (default: ``1``)
 
 

--- a/i3pystatus/clock.py
+++ b/i3pystatus/clock.py
@@ -16,8 +16,10 @@ class Clock(IntervalModule):
 
     settings = (
         ("format", "stftime format string, `None` means to use the default, locale-dependent format"),
+        ("color", "RGB hexadecimal code color specifier, default to #ffffff, set to `i3Bar` to use i3 bar default"),
     )
     format = None
+    color = "#ffffff"
     interval = 1
 
     def init(self):
@@ -37,5 +39,6 @@ class Clock(IntervalModule):
         self.output = {
             "full_text": datetime.datetime.now().strftime(self.format),
             "urgent": False,
-            "color": "#ffffff"
         }
+        if self.color != "i3Bar":
+            self.output["color"] = self.color


### PR DESCRIPTION
Allow specifying a custom color used to display the time.

Specifying i3Bar will avoid settting the color and use default color from i3bar config.
If nothing is specified it default to #ffffff ti be backward compatible.
