### PR TITLE
README: document that naming the script i3pystatus.py will break imports.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ Packages for your OS
 
 * `Arch Linux <https://aur.archlinux.org/packages/i3pystatus-git/>`_
 
+Do not name your script i3pystatus.py or it will break imports.
+
 Release Notes
 -------------
 


### PR DESCRIPTION
Document that naming the script i3pystatus.py will break imports. Fix for #37.
