### PR TITLE
README: Weather module displays incorrect args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -803,7 +803,7 @@ Requires pywapi from PyPI.
 Settings:
 
 :location_code:  (required)
-:units: Celsius (C) or Fahrenheit (F) (default: ``C``)
+:units: Celsius (``metric``) or Fahrenheit (``imperial``) (default: ``metric``)
 :format:  (default: ``{current_temp}``)
 :interval:  (default: ``20``)
 


### PR DESCRIPTION
i3pystatus source: https://github.com/enkore/i3pystatus/blob/master/i3pystatus/weather.py#L21
pywapi documentation: https://code.google.com/p/python-weather-api/#Documentation

`metric` and `imperial`.
