### PR TITLE
Make temp base path configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -868,6 +868,7 @@ Settings:
 :color_critical:  (default: ``#FF0000``)
 :high_factor:  (default: ``0.7``)
 :interval:  (default: ``5``)
+:base_path:  (default: ``/sys/devices/platform/coretemp.0``)
 
 
 

--- a/i3pystatus/temp.py
+++ b/i3pystatus/temp.py
@@ -21,9 +21,9 @@ class Temperature(IntervalModule):
     color = "#FFFFFF"
     color_high = "#FFFF00"
     color_critical = "#FF0000"
+    base_path = "/sys/devices/platform/coretemp.0"
 
     def init(self):
-        self.base_path = "/sys/devices/platform/coretemp.0"
         input = glob.glob(
             "{base_path}/temp*_input".format(base_path=self.base_path))[0]
         self.input = re.search("temp([0-9]+)_input", input).group(1)


### PR DESCRIPTION
I booted up and this was not set correctly (the file did not exist), as
it had somehow moved around during a reboot. Not sure if this is
something that changed in kernel 3.15, but it might be.
