### PR TITLE
Support optional "format_muted" setting for audio modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,6 +329,7 @@ Available formatters:
 Settings:
 
 :format:  (default: ``♪: {volume}``)
+:format_muted: optional format string to use when muted (default: ``None``)
 :mixer: ALSA mixer (default: ``Master``)
 :mixer_id: ALSA mixer id (default: ``0``)
 :card: ALSA sound card (default: ``0``)
@@ -753,6 +754,7 @@ Available formatters:
 Settings:
 
 :format:  (default: ``♪: {volume}``)
+:format_muted: optional format string to use when muted (default: ``None``)
 :muted:  (default: ``M``)
 :unmuted:  (default: ````)
 

--- a/i3pystatus/alsa.py
+++ b/i3pystatus/alsa.py
@@ -21,6 +21,7 @@ class ALSA(IntervalModule):
 
     settings = (
         "format",
+        ("format_muted", "optional format string to use when muted"),
         ("mixer", "ALSA mixer"),
         ("mixer_id", "ALSA mixer id"),
         ("card", "ALSA sound card"),
@@ -34,6 +35,7 @@ class ALSA(IntervalModule):
     color_muted = "#AAAAAA"
     color = "#FFFFFF"
     format = "♪: {volume}"
+    format_muted = None
     mixer = "Master"
     mixer_id = 0
     card = 0
@@ -68,7 +70,12 @@ class ALSA(IntervalModule):
         self.fdict["volume"] = self.alsamixer.getvolume()[self.channel]
         self.fdict["muted"] = self.muted if muted else self.unmuted
 
+        if muted and self.format_muted is not None:
+            output_format = self.format_muted
+        else:
+            output_format = self.format
+
         self.output = {
-            "full_text": self.format.format(**self.fdict),
+            "full_text": output_format.format(**self.fdict),
             "color": self.color_muted if muted else self.color,
         }

--- a/i3pystatus/pulseaudio/__init__.py
+++ b/i3pystatus/pulseaudio/__init__.py
@@ -17,12 +17,14 @@ class PulseAudio(Module):
 
     settings = (
         "format",
+        ("format_muted", "optional format string to use when muted"),
         "muted", "unmuted"
     )
 
     muted = "M"
     unmuted = ""
     format = "♪: {volume}"
+    format_muted = None
 
     def init(self):
         """Creates context, when context is ready context_notify_cb is called"""
@@ -97,8 +99,13 @@ class PulseAudio(Module):
 
             muted = self.muted if sink_info.mute else self.unmuted
 
+            if muted and self.format_muted is not None:
+                output_format = self.format_muted
+            else:
+                output_format = self.format
+
             self.output = {
-                "full_text": self.format.format(
+                "full_text": output_format.format(
                     muted=muted,
                     volume=volume_percent,
                     db=volume_db),


### PR DESCRIPTION
The alsa and pulseaudio modules now support an optional "format_muted"
setting. If provided, it will be used instead of "format" when the audio
is muted.
