### PR TITLE
Battery Module - No text when 100%

### DIFF
--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -173,7 +173,7 @@ class BatteryChecker(IntervalModule):
             }
             return
         if self.no_text_full:
-            if battery.percentage() > 99.9:
+            if battery.status() == 'Full':
               self.output = {
                   "full_text": ""
               }


### PR DESCRIPTION
When battery is full I always prefer no text displayed at all. I don't think it's necessary to see 100% or "Full" everytime my laptop is on AC mode.
