### PR TITLE
This patch allows the notmuch backend to retrieve the notmuch database p...

### DIFF
--- a/i3pystatus/mail/notmuchmail.py
+++ b/i3pystatus/mail/notmuchmail.py
@@ -4,7 +4,8 @@
 # note that this needs the notmuch python bindings. For more info see:
 # http://notmuchmail.org/howto/#index4h2
 import notmuch
-
+import configparser
+import os
 from i3pystatus.mail import Backend
 
 
@@ -15,9 +16,27 @@ class Notmuch(Backend):
     and "unread"
     """
 
-    settings = required = ("db_path",)
+    settings = (
+       ("db_path","Path to the directory of your notmuch database"),
+            )
+
+    db_path = None;
 
     def init(self):
+        
+        if not self.db_path:
+            defaultConfigFilename= os.path.expanduser("~/.notmuch-config")
+            config = configparser.RawConfigParser()
+            
+            # read tries to read and returns successfully read filenames
+            successful = config.read( [
+                os.environ.get("NOTMUCH_CONFIG",defaultConfigFilename),
+                defaultConfigFilename
+                ] 
+                ) 
+
+            self.db_path = config.get("database","path")
+
         self.db = notmuch.Database(self.db_path)
 
     @property


### PR DESCRIPTION
...ath from the notmuch configuration file in case no "db_path" argument is passed to the Notmuch constructor.

In such a case, i3pystatus will try to load the file designed by the
environment variable NOTMUCH_CONFIG and "~/.notmuch_config". and
retrieve the value "path" of the section [database].

I don't handle the errors such as "section database doesn't exist" as i3pystatus policy looks to be minimal checking. There might be a case where NOTMUCH_CONFIG file actually exists and is different from an existing ~/.notmuch_config. The value of .notmuch_config may be taken instead of the one from NOTMUCH_CONFIG but I am not sure it's worth treating.
