### PR TITLE
this commit fixes 2 problems:

### DIFF
--- a/i3pystatus/alsa.py
+++ b/i3pystatus/alsa.py
@@ -25,7 +25,7 @@ class ALSA(IntervalModule):
         ("mixer", "ALSA mixer"),
         ("mixer_id", "ALSA mixer id"),
         ("card", "ALSA sound card"),
-        ("increment","integer percentage of max volume to in/decrement volume on mousewheel"),
+        ("increment", "integer percentage of max volume to in/decrement volume on mousewheel"),
         "muted", "unmuted",
         "color_muted", "color",
         "channel"
@@ -87,13 +87,13 @@ class ALSA(IntervalModule):
 
     def on_rightclick(self):
         if self.has_mute:
-            muted = self.alsamixer.getmute()[self.channel] 
-            self.alsamixer.setmute( not muted )
+            muted = self.alsamixer.getmute()[self.channel]
+            self.alsamixer.setmute(not muted)
 
     def on_upscroll(self):
         vol = self.alsamixer.getvolume()[self.channel]
-        self.alsamixer.setvolume( vol + self.increment)
+        self.alsamixer.setvolume(min(100, vol + self.increment))
 
     def on_downscroll(self):
         vol = self.alsamixer.getvolume()[self.channel]
-        self.alsamixer.setvolume( vol - self.increment)
+        self.alsamixer.setvolume(max(0, vol - self.increment))

--- a/i3pystatus/clock.py
+++ b/i3pystatus/clock.py
@@ -59,7 +59,7 @@ class Clock(IntervalModule):
         else:
             dt = datetime.datetime.now()
 
-        output = dt.strftime(self.format[self.current_format_id][0]),
+        output = dt.strftime(self.format[self.current_format_id][0])
 
         self.output = {
             "full_text": output,


### PR DESCRIPTION
-there was a trailing comma in the clock module that would interact badly with i3pystatus & i3bar; i3pystatus seeing the comma would generate the json *\* full_text : ["13 september"] *\* and then i3bar would only display the last module (one may have to check for i3bar robustness). resulted in having only the clock module displayed
-the 2nd problem was with the alsa module when setting the volume to a number < 0 or >100 then the pyalsa bindings would generate the following error in .xsession-errors

```
    target_module.on_click(command["button"])↲
  File "/home/teto/i3pystatus/i3pystatus/core/modules.py", line 31, in
  on_click↲
      self.on_upscroll()↲
        File "/home/teto/i3pystatus/i3pystatus/alsa.py", line 95, in
    on_upscroll↲
        self.alsamixer.setvolume( vol + self.increment)↲
        alsaaudio.ALSAAudioError: Volume must be between 0 and 100↲
```

I also improved PEP8 compliance in 2/3 places
