### PR TITLE
Fix internet() test function

### DIFF
--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -353,12 +353,13 @@ def require(predicate):
 
 def internet():
     """
-    Checks for a internet connection by connecting to 8.8.8.8 (Google DNS)
+    Checks for a internet connection by connecting to a Google DNS
+    server.
 
     :returns: True if internet connection is available
     """
     try:
-        socket.create_connection(("www.google.de", 53), 1).close()
+        socket.create_connection(("google-public-dns-a.google.com", 53), 1).close()
         return True
     except OSError:
         return False


### PR DESCRIPTION
The change in commit 6989713 broke the internet() test function by
trying to access the DNS port of "www.google.de", causing it to always
return False, which in turn broke all modules calling it. We instead use
the actual domain name of Google's DNS server at IP "8.8.8.8".
