### PR TITLE
Add color settings for muted/unmuted to pulseaudio plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -988,6 +988,8 @@ Settings:
 :format_muted: optional format string to use when muted (default: ``None``)
 :muted:  (default: ``M``)
 :unmuted:  (default: ````)
+:color_muted:  (default: ``#FF0000``)
+:color_unmuted:  (default: ``#FFFFFF``)
 
 
 

--- a/i3pystatus/pulseaudio/__init__.py
+++ b/i3pystatus/pulseaudio/__init__.py
@@ -18,13 +18,16 @@ class PulseAudio(Module):
     settings = (
         "format",
         ("format_muted", "optional format string to use when muted"),
-        "muted", "unmuted"
+        "muted", "unmuted",
+        "color_muted", "color_unmuted"
     )
 
     muted = "M"
     unmuted = ""
     format = "♪: {volume}"
     format_muted = None
+    color_muted = "#FF0000"
+    color_unmuted = "#FFFFFF"
 
     def init(self):
         """Creates context, when context is ready context_notify_cb is called"""
@@ -98,6 +101,7 @@ class PulseAudio(Module):
                 volume_db = int(volume_db)
 
             muted = self.muted if sink_info.mute else self.unmuted
+            color = self.color_muted if sink_info.mute else self.color_unmuted
 
             if muted and self.format_muted is not None:
                 output_format = self.format_muted
@@ -105,6 +109,7 @@ class PulseAudio(Module):
                 output_format = self.format
 
             self.output = {
+                "color": color,
                 "full_text": output_format.format(
                     muted=muted,
                     volume=volume_percent,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name="i3pystatus",
-      version="3.30",
+      version="3.31",
       description="Like i3status, this generates status line for i3bar / i3wm",
       url="http://github.com/enkore/i3pystatus",
       license="MIT",


### PR DESCRIPTION
I use fontawesome icons for theming my i3 heavily, and found that using colors for everything make it look a lot nicer.

Most plugins already have this, so I added config for it to the pulseaudio plugin as well
