### PR TITLE
[RFC] Custom callback on clicks

### DIFF
--- a/i3pystatus/clock.py
+++ b/i3pystatus/clock.py
@@ -71,8 +71,8 @@ class Clock(IntervalModule):
         if self.color != "i3Bar":
             self.output["color"] = self.color
 
-    def next_format(self):
-        self.current_format_id = (self.current_format_id + 1) % len(self.format)
+    def next_format(self,step=1):
+        self.current_format_id = (self.current_format_id + step) % len(self.format)
 
     def previous_format(self):
         self.current_format_id = (self.current_format_id + 1) % len(self.format)

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -7,7 +7,6 @@ from i3pystatus.core.imputil import ClassFinder
 from i3pystatus.core import io, util
 from i3pystatus.core.modules import Module
 
-
 class CommandEndpoint:
     """
     Endpoint for i3bar click events: http://i3wm.org/docs/i3bar-protocol.html#_click_events

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -4,10 +4,12 @@ from subprocess import check_output, CalledProcessError
 
 class Command(object):
 
-    args = []
+    args = None
+    kwargs= None
     command = ""
     def __init__(self, command, *args,**kwargs):
         self.args = args;
+        self.kwargs = kwargs
         self.command = command
 
     def run(self, module):
@@ -15,21 +17,21 @@ class Command(object):
         Returns tuple boolean (success)/ string (error msg, output)
         """
        
-        
+        # print("RUN")
 
         # if it is a python fct, then run it
         if callable(self.command):
-            self.command(self.args)
+            self.command(*self.args)
         #
         elif hasattr(module,self.command):
-            pass
+            getattr(module,self.command)(*self.args,**self.kwargs)
         # it it is a string (as a last resort, then run the process with args
         else:
             return self.run_through_shell(self.command)
 
     # def __call__(self):
 
-    @staticmethod
+    
     # def run_through_shell(module, member,*args):
 
 

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -7,9 +7,9 @@ class Module(SettingsBase):
     output = None
     position = 0
     
-    settings = tuple(
-        ("on_lclick","callback when left clicking")
-        ("on_rclick","callback when left clicking")
+    settings = (
+        ("on_lclick","callback when left clicking"),
+        ("on_rclick","callback when left clicking"),
         )
 
     def registered(self, status_handler):

--- a/i3pystatus/core/settings.py
+++ b/i3pystatus/core/settings.py
@@ -84,7 +84,7 @@ class SettingsBase(object):
         #     settings = settings + ( super().flatten_settings(), )
             # settings = super().flatten_settings()
 
-        print("Settings after loop: \n", settings)
+        # print("Settings after loop: \n", settings)
         def flatten_setting(setting):
             return setting[0] if isinstance(setting, tuple) else setting
 


### PR DESCRIPTION
This is not meant as a PR yet, but more as a request for comments, on how to tackle the following problem. As such it's not pep8 compliant or clean.

i3pystatus introduces click supports with on_leftclick()/on_rightclick() members but their behavior is hardcoded. I believe it would be more interesting to still provide a default behavior, yet allow to easily override it.

There could be several way to do it such as:

```
clock=status.register("clock", ...)
clock.on_leftclick = (myCallback)
```

but as the i3pystatus examples (thus users) don't get the value returned by status.register, I've preferred to set the callbacks as additional "settings" (I refer to the member variable). i3pystatus modules do not take into account its parent settings so I've implemented "settings" inheritance (could be done in a more backward compatible way I guess since I changed the flatten_settings() prototype ). For instance the setting _on_lclick_ is implemented in the "Module" class and inherited by all its children.
I provide a "Command" wrapper that is able to:
- call a module member function 
- or launch an external script ( i3pystatus needs a generic function to launch subprocesses since it is used in several places). 
- Ideally it could also execute a user python function.

Here is an example of how to use the current interface.

```
[...legacy status configuration...]

from i3pystatus.core.command import Command

clock=status.register("clock", format=[
            "%a %-d %b %X toto",
            ("%a %-d %b %X",'Europe/Paris'),
 ],
# will execute an external process
on_lclick=Command("notify-send 'hello world'")
# call member function
,on_rclick=Command("next_format",3)
   )
```

Nb: I noticed some similarities between powerline and i3pystatus, maybe there could be some convergence between the 2 ?
