### PR TITLE
network_traffic: allow to hide down interfaces

### DIFF
--- a/i3pystatus/network_traffic.py
+++ b/i3pystatus/network_traffic.py
@@ -30,7 +30,7 @@ class NetworkTraffic(IntervalModule):
 
     format = "{interface} \u2197{bytes_sent}kB/s \u2198{bytes_recv}kB/s"
     format_down = "{interface} \u2013"
-    hide_down = True
+    hide_down = False
     interface = "eth0"
     divisor = 1024
     round_size = None


### PR DESCRIPTION
Interfaces which are down can be hidden or formatted differently.

The following options are added:
hide_down - whether to not display a interface which is down
format_down - format string if the interface is down (unless hide_down is set)
