### PR TITLE
mpd text length

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -89,7 +89,7 @@ class MPD(IntervalModule):
 
         for key in self.truncate_fields:
             if len(fdict[key]) > self.text_len:
-                fdict[key] = fdict[key][:self.text_len-1] + "…"
+                fdict[key] = fdict[key][:self.text_len - 1] + "…"
 
         if not fdict["title"] and "filename" in fdict:
             fdict["filename"] = '.'.join(


### PR DESCRIPTION
new version of #131

I decided against a regex based approach, because in my opinion it makes not much sense cuting the middle part in this case, thus using regex would just add unnecessary complexity.
