### PR TITLE
Add pianobar module

### DIFF
--- a/i3pystatus/pianobar.py
+++ b/i3pystatus/pianobar.py
@@ -8,6 +8,9 @@ class Pianobar(IntervalModule):
     In pianobar config file must be setted the fifo and event_command options
     (see man pianobar for more information)
 
+    For the event_cmd use:
+    https://github.com/jlucchese/pianobar/blob/master/contrib/pianobar-song-i3.sh
+
     Mouse events:
     - Left click play/pauses
     - Right click plays next song


### PR DESCRIPTION
Pianobar is a console-based player for pandora.com. This module will show the current playing song and add mouse events for next song, play/pause and volume management. It is important to ensure to set fifo and event_cmd options on pianobar config file.
For the event_cmd use https://github.com/jlucchese/pianobar/blob/master/contrib/pianobar-song-i3.sh
