### PR TITLE
Simple fix for notmuch database not in sync

### DIFF
--- a/i3pystatus/mail/__init__.py
+++ b/i3pystatus/mail/__init__.py
@@ -43,6 +43,10 @@ class Mail(IntervalModule):
             pass
 
     def run(self):
+        """
+        Returns the sum of unread messages across all registered backends
+        """
+
         unread = sum(map(lambda backend: backend.unread, self.backends))
 
         if not unread:

--- a/i3pystatus/mail/notmuchmail.py
+++ b/i3pystatus/mail/notmuchmail.py
@@ -38,7 +38,9 @@ class Notmuch(Backend):
     @property
     def unread(self):
         db = notmuch.Database(self.db_path)
-        return notmuch.Query(db, "tag:unread and tag:inbox").count_messages()
+        result = notmuch.Query(db, "tag:unread and tag:inbox").count_messages()
+        db.close()
+        return result
 
 
 Backend = Notmuch


### PR DESCRIPTION
I first intended to fix https://github.com/enkore/i3pystatus/issues/121 by capturing stderr from the C library but it introduces too much complexity. Instead this patch just opens and closes the database for each request. I don't believe it has much overhead (just opening a file) though I have no benchmark. I believe it's possible to open the db, <db modified by an outer program>, then having the notmuch request fail (because of an outdated db) but with a much lower probability. Anyway it would be refreshed in the next interval. Hope notmuch team fixes this though.
