### PR TITLE
Mpd truncation improvement

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -35,8 +35,8 @@ class MPD(IntervalModule):
         ("format", "formatp string"),
         ("status", "Dictionary mapping pause, play and stop to output"),
         ("color", "The color of the text"),
-        ("max_field_len", "Defines max length for in truncate_fields defined fields, if truncated, ellipsis are appended as indicator. Value of 0 disables this."),
-        ("max_len", "Defines max length for the hole string, if exceeding fields specefied in truncate_fields are truncated equaly. If truncated, ellipsis are appended as indicator. Value of 0 disables this."),
+        ("max_field_len", "Defines max length for in truncate_fields defined fields, if truncated, ellipsis are appended as indicator. It's applied *before* max_len. Value of 0 disables this."),
+        ("max_len", "Defines max length for the hole string, if exceeding fields specefied in truncate_fields are truncated equaly. If truncated, ellipsis are appended as indicator. It's applied *after* max_field_len. Value of 0 disables this."),
         ("truncate_fields", "fields that will be truncated if exceeding max_field_len or max_len, whatever catches first takes effect"),
 
     )

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -109,8 +109,8 @@ class MPD(IntervalModule):
         full_text = formatp(self.format, **fdict).strip()
         full_text_len = len(full_text)
         if full_text_len > self.max_len and self.max_len > 0:
-            shrink = floor((self.max_len - full_text_len)
-                           / len(self.truncate_fields)) - 1
+            shrink = floor((self.max_len - full_text_len) /
+                           len(self.truncate_fields)) - 1
 
             for key in self.truncate_fields:
                 fdict[key] = fdict[key][:shrink] + "…"

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -101,13 +101,14 @@ class MPD(IntervalModule):
         else:
             fdict["filename"] = ""
 
-        for key in self.truncate_fields:
-            if len(fdict[key]) > self.max_field_len:
-                fdict[key] = fdict[key][:self.max_field_len - 1] + "…"
+        if self.max_field_len > 0:
+            for key in self.truncate_fields:
+                if len(fdict[key]) > self.max_field_len:
+                    fdict[key] = fdict[key][:self.max_field_len - 1] + "…"
 
         full_text = formatp(self.format, **fdict).strip()
         full_text_len = len(full_text)
-        if full_text_len > self.max_len:
+        if full_text_len > self.max_len and self.max_len > 0:
             shrink = floor((self.max_len - full_text_len)
                            / len(self.truncate_fields)) - 1
 

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -105,7 +105,8 @@ class MPD(IntervalModule):
             if len(fdict[key]) > self.max_field_len:
                 fdict[key] = fdict[key][:self.max_field_len - 1] + "…"
 
-        full_text_len = len(formatp(self.format, **fdict).strip())
+        full_text = formatp(self.format, **fdict).strip()
+        full_text_len = len(full_text)
         if full_text_len > self.max_len:
             shrink = floor((self.max_len - full_text_len)
                            / len(self.truncate_fields)) - 1
@@ -113,8 +114,10 @@ class MPD(IntervalModule):
             for key in self.truncate_fields:
                 fdict[key] = fdict[key][:shrink] + "…"
 
+            full_text = formatp(self.format, **fdict).strip()
+
         self.output = {
-            "full_text": formatp(self.format, **fdict).strip(),
+            "full_text": full_text,
             "color": self.color,
         }
 

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -37,7 +37,7 @@ class MPD(IntervalModule):
         ("color", "The color of the text"),
         ("max_field_len", "Defines max length for in truncate_fields defined fields, if truncated, ellipsis are appended as indicator. It's applied *before* max_len. Value of 0 disables this."),
         ("max_len", "Defines max length for the hole string, if exceeding fields specefied in truncate_fields are truncated equaly. If truncated, ellipsis are appended as indicator. It's applied *after* max_field_len. Value of 0 disables this."),
-        ("truncate_fields", "fields that will be truncated if exceeding max_field_len or max_len, whatever catches first takes effect"),
+        ("truncate_fields", "fields that will be truncated if exceeding max_field_len or max_len."),
 
     )
 


### PR DESCRIPTION
Improves output truncation in mpd module, for this a new parameter, max_len, is introduced. If the output length exceeds max_len all in truncate_fields specefied fields are truncated by the same value.

To prevent problems with one very long field, in contrary to what i proposed in #169, max_field_len is applied first, of not disabled.