### PR TITLE
Try/Except the pywapi call

### DIFF
--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -42,7 +42,10 @@ class Weather(IntervalModule):
 
     @require(internet)
     def run(self):
-        result = pywapi.get_weather_from_weather_com(self.location_code, self.units)
+        try:
+            result = pywapi.get_weather_from_weather_com(self.location_code, self.units)
+        except AttributeError:
+            return False
         conditions = result["current_conditions"]
         temperature = conditions["temperature"]
         humidity = conditions["humidity"]


### PR DESCRIPTION
Often, the pywapi.get_weather... call will yield a "'NoneType' object has no attribute 'data' error" if the weather call does not work properly. 
This is usually resolved on the next call, but leads to an ugly warning in the status bar.
I simply wrapped the pywapi call in a try-except block where the except condition returns False. (Perhaps instead it should output something to a log file?)
This solved the problem for me.

PS: This is my first attempt at proposing a change, so if I'm not doing it right I'd love to be pointed to an intro to contributing to Github projects or something similar.