### PR TITLE
Remove 'u' prefix from unicode strings

### DIFF
--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -383,7 +383,7 @@ def make_graph(values, lower_limit=0.0, upper_limit=100.0, style="blocks"):
     extent = mx - mn
 
     if style == 'blocks':
-        bar = u'_▁▂▃▄▅▆▇█'
+        bar = '_▁▂▃▄▅▆▇█'
         bar_count = len(bar) - 1
         if extent == 0:
             graph = '_' * len(values)
@@ -436,7 +436,7 @@ def make_vertical_bar(percentage, width=1):
     :param width: How many characters wide the bar should be.
     :returns: Bar as a String
     """
-    bar = u' _▁▂▃▄▅▆▇█'
+    bar = ' _▁▂▃▄▅▆▇█'
     percentage //= 10
     if percentage < 0:
         output = bar[0]

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -16,7 +16,7 @@ class Github(IntervalModule):
     * `{unread_count}`  - number of unread notifications, empty if 0
     """
 
-    unread_marker = u"●"
+    unread_marker = "●"
     unread = ''
     color = '#78EAF2'
     username = ''


### PR DESCRIPTION
Not necessary in Python 3