### PR TITLE
Truncate long error messages.

### DIFF
--- a/i3pystatus/core/threading.py
+++ b/i3pystatus/core/threading.py
@@ -75,9 +75,17 @@ class ExceptionWrapper(Wrapper):
             sys.stderr.flush()
             if hasattr(self.workload, "output"):
                 self.workload.output = {
-                    "full_text": "{}: {}".format(self.workload.__class__.__name__, sys.exc_info()[1]),
+                    "full_text": "{}: {}".format(self.workload.__class__.__name__,
+                                                 self.format_error(str(sys.exc_info()[1]))),
                     "color": "#FF0000",
                 }
+
+    def format_error(self, exception_message):
+        if hasattr(self.workload, 'max_error_len'):
+            error_len = self.workload.max_error_len
+            return exception_message[:error_len] + '...' if len(exception_message) > error_len else exception_message
+        else:
+            return exception_message
 
 
 class WorkloadWrapper(Wrapper):

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -16,6 +16,7 @@ class Github(IntervalModule):
     * `{unread_count}`  - number of unread notifications, empty if 0
     """
 
+    max_error_len = 50
     unread_marker = "●"
     unread = ''
     color = '#78EAF2'
@@ -49,8 +50,6 @@ class Github(IntervalModule):
         # Bad credentials
         if isinstance(data, dict):
             err_msg = data['message']
-            if len(err_msg) > 10:
-                err_msg = "%s%s" % (err_msg[:10], '...')
             raise ConfigError(err_msg)
 
         unread = len(data)


### PR DESCRIPTION
Some module have very verbose error messages which fill up most of the screen. These commits allow adding a `max_error_len` variable to a module to truncate error messages longer than this value. 