### PR TITLE
Better default for critical load limit

### DIFF
--- a/i3pystatus/load.py
+++ b/i3pystatus/load.py
@@ -1,4 +1,5 @@
 from i3pystatus import IntervalModule
+from multiprocessing import cpu_count
 
 
 class Load(IntervalModule):
@@ -17,7 +18,7 @@ class Load(IntervalModule):
 
     file = "/proc/loadavg"
     color = "#ffffff"
-    critical_limit = 1
+    critical_limit = cpu_count()
     critical_color = "#ff0000"
 
     def run(self):

--- a/i3pystatus/load.py
+++ b/i3pystatus/load.py
@@ -1,5 +1,8 @@
 from i3pystatus import IntervalModule
-from os import cpu_count
+try:
+    from os import cpu_count
+except ImportError:
+    from multiprocessing import cpu_count
 
 
 class Load(IntervalModule):

--- a/i3pystatus/load.py
+++ b/i3pystatus/load.py
@@ -12,7 +12,7 @@ class Load(IntervalModule):
         ("format",
          "format string used for output. {avg1}, {avg5} and {avg15} are the load average of the last one, five and fifteen minutes, respectively. {tasks} is the number of tasks (i.e. 1/285, which indiciates that one out of 285 total tasks is runnable)."),
         ("color", "The text color"),
-        ("critical_limit", "Limit above which the load is considered critical"),
+        ("critical_limit", "Limit above which the load is considered critical, defaults to amount of cores."),
         ("critical_color", "The critical color"),
     )
 

--- a/i3pystatus/load.py
+++ b/i3pystatus/load.py
@@ -1,5 +1,5 @@
 from i3pystatus import IntervalModule
-from multiprocessing import cpu_count
+from os import cpu_count
 
 
 class Load(IntervalModule):


### PR DESCRIPTION
The load average calculation routines does not consider the amount of cores. This leads to the problem, that it has to interpreted based on the amount of cores that are in the system.
While a threshold of 1 might be a sane default for a single core system it is not for systems with more than one core. A system with 8 cores is nowhere near overload with 2 process in run queue.

This patch sets the default to the number of cores using os.cpu_count or as a fallback multiprocessing.cpu_count because the version from os is not available before python 3.4.