### PR TITLE
Add support for multiple batteries

### DIFF
--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -151,7 +151,7 @@ class BatteryChecker(IntervalModule):
         ("charging_color", "The charging color"),
         ("critical_color", "The critical color"),
         ("not_present_color", "The not present color."),
-        ("no_present_text", "The text to display when the battery is not present. Provides {battery_ident} as formatting option"),
+        ("not_present_text", "The text to display when the battery is not present. Provides {battery_ident} as formatting option"),
         ("no_text_full", "Don't display text when battery is full - 100%"),
     )
 

--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -119,6 +119,8 @@ class BatteryChecker(IntervalModule):
     """
     This class uses the /sys/class/power_supply/…/uevent interface to check for the
     battery status
+    It provides the "ALL" battery_ident which will summarise all available batteries
+    for the moment and aggregate the % as well as the time remaining on the charge.
 
     .. rubric:: Available formatters
 

--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -129,7 +129,7 @@ class BatteryChecker(IntervalModule):
     * `{percentage_design}` — absolute battery charge percentage
     * `{consumption (Watts)}` — current power flowing into/out of the battery
     * `{status}`
-    # `{no_of_batteries}` — The number of batteries included
+    * `{no_of_batteries}` — The number of batteries included
     * `{battery_ident}` — the same as the setting
     * `{bar}` —bar displaying the percentage graphically
     """


### PR DESCRIPTION
Some modifications I made locally to add support for multiple batteries (as present in the Thinkpad T440s and T450s), if you use the new default battery_ident "ALL" it will summarise all batteries. You can still set the battery manually by adding battery_ident to the keyword argument list when registering the status.
It also adds a new format output `no_of_batteries` which displays the count of batteries currently present.
It supports hotswapping of batteries. :)