### PR TITLE
Initial commit of openstack_vms.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ MOCK_MODULES = [
     "notmuch",
     "requests",
     "bs4",
-    "python-novaclient"
+    "novaclient.v2"
 ]
 
 for mod_name in MOCK_MODULES:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,8 @@ MOCK_MODULES = [
     "i3pystatus.pulseaudio.pulse",
     "notmuch",
     "requests",
-    "bs4"
+    "bs4",
+    "python-novaclient"
 ]
 
 for mod_name in MOCK_MODULES:

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -17,12 +17,10 @@ class Openstack_vms(IntervalModule):
         ("username", "Username for OpenStack authentication (OS_USERNAME)"),
         ("password", "Password for Openstack authentication (OS_PASSWORD)"),
         ("tenant_name", "Tenant/Project name to view (OS_TENANT_NAME)"),
-        ("color", "Display color when non-active VMs are =< `threshold` "
-            "(default: #00FF00"),
-        ("crit_color", "Display color when non-active VMs are => `threshold` "
-            "(default: #FF0000"),
+        ("color", "Display color when non-active VMs are =< `threshold`"),
+        ("crit_color", "Display color when non-active VMs are => `threshold`").
         ("threshold", "Set critical indicators when non-active VM pass this "
-            "number (default: 0)"),
+            "number"),
         ("horizon_url", "When clicked, open this URL in a browser")
     )
     required = ("auth_url", "password", "tenant_name", "username")

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -17,11 +17,11 @@ class Openstack_vms(IntervalModule):
         ("password", "Password for Openstack authentication (OS_PASSWORD)"),
         ("tenant_name", "Tenant/Project name to view (OS_TENANT_NAME)"),
         ("color", "Display color when non-active VMs are =< `threshold` "
-        "(default: #00FF00"),
+            "(default: #00FF00"),
         ("crit_color", "Display color when non-active VMs are => `threshold` "
-        "(default: #FF0000"),
+            "(default: #FF0000"),
         ("threshold", "Set critical indicators when non-active VM pass this "
-         "number (default: 0)"),
+            "number (default: 0)"),
         ("horizon_url", "When clicked, open this URL in a browser")
     )
     required = ("auth_url", "password", "tenant_name", "username")
@@ -29,7 +29,8 @@ class Openstack_vms(IntervalModule):
     crit_color = "#FF0000"
     threshold = 0
     horizon_url = None
-    format = "{tenant_name}: {active_servers} active, {nonactive_servers} non-active"
+    format = "{tenant_name}: {active_servers} active, "\
+        "{nonactive_servers} non-active"
 
     on_leftclick = "openurl"
 

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -18,7 +18,7 @@ class Openstack_vms(IntervalModule):
         ("password", "Password for Openstack authentication (OS_PASSWORD)"),
         ("tenant_name", "Tenant/Project name to view (OS_TENANT_NAME)"),
         ("color", "Display color when non-active VMs are =< `threshold`"),
-        ("crit_color", "Display color when non-active VMs are => `threshold`").
+        ("crit_color", "Display color when non-active VMs are => `threshold`"),
         ("threshold", "Set critical indicators when non-active VM pass this "
             "number"),
         ("horizon_url", "When clicked, open this URL in a browser")

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -9,6 +9,7 @@ class Openstack_vms(IntervalModule):
     """
     Displays the number of VMs in an openstack cluster in ACTIVE and
     non-ACTIVE states.
+    Requires: python-novaclient
     """
 
     settings = (

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -1,5 +1,4 @@
 from i3pystatus import IntervalModule
-from .core.util import round_dict
 # requires python-novaclient
 from novaclient.v2 import client
 import webbrowser

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -1,0 +1,69 @@
+from i3pystatus import IntervalModule
+from .core.util import round_dict
+# requires python-novaclient
+from novaclient.v2 import client
+import webbrowser
+
+
+class Openstack_vms(IntervalModule):
+    """
+    Displays the number of VMs in an openstack cluster in ACTIVE and
+    non-ACTIVE states.
+    """
+
+    settings = (
+        ("auth_url", "OpenStack cluster authentication URL (OS_AUTH_URL)"),
+        ("username", "Username for OpenStack authentication (OS_USERNAME)"),
+        ("password", "Password for Openstack authentication (OS_PASSWORD)"),
+        ("tenant_name", "Tenant/Project name to view (OS_TENANT_NAME)"),
+        ("color", "Display color when non-active VMs are =< `threshold` "
+        "(default: #00FF00"),
+        ("crit_color", "Display color when non-active VMs are => `threshold` "
+        "(default: #FF0000"),
+        ("threshold", "Set critical indicators when non-active VM pass this "
+         "number (default: 0)"),
+        ("horizon_url", "When clicked, open this URL in a browser")
+    )
+    required = ("auth_url", "password", "tenant_name", "username")
+    color = "#00FF00"
+    crit_color = "#FF0000"
+    threshold = 0
+    horizon_url = None
+    format = "{tenant_name}: {active_servers} active, {nonactive_servers} non-active"
+
+    on_leftclick = "openurl"
+
+    def run(self):
+        nclient = client.Client(
+            self.username,
+            self.password,
+            self.tenant_name,
+            self.auth_url
+        )
+
+        active_servers = 0
+        nonactive_servers = 0
+        server_list = nclient.servers.list()
+        for server in server_list:
+            if server.status == 'ACTIVE':
+                active_servers = active_servers + 1
+            else:
+                nonactive_servers = nonactive_servers + 1
+
+        if nonactive_servers > self.threshold:
+            display_color = self.crit_color
+        else:
+            display_color = self.color
+        cdict = {
+            "tenant_name": self.tenant_name,
+            "active_servers": active_servers,
+            "nonactive_servers": nonactive_servers,
+        }
+
+        self.output = {
+            "full_text": self.format.format(**cdict),
+            "color": display_color
+        }
+
+    def openurl(self):
+        webbrowser.open_new_tab(self.horizon_url)


### PR DESCRIPTION
This patch provides an module for tracking the number of active and
non-active VMs in a given openstack cluster.  When non-"ACTIVE" VMs
are above a given threshold, the text will (by default) change to
red, thus indicating an issue.  Otherwise, the text will be green.