### PR TITLE
Truncat openstack_vms output some

### DIFF
--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -27,8 +27,8 @@ class Openstack_vms(IntervalModule):
     crit_color = "#FF0000"
     threshold = 0
     horizon_url = None
-    format = "{tenant_name}: {active_servers} active, "\
-        "{nonactive_servers} non-active"
+    format = "{tenant_name}: {active_servers} up, "\
+        "{nonactive_servers} down"
 
     on_leftclick = "openurl"
 


### PR DESCRIPTION
The output for openstack_vms was a bit too verbose, causing it too
consume too much of the status bar.  This patch uses smaller words
that may be less accurate, but portray the same general idea.