### PR TITLE
makewatch: a module to watch for make (or other long running) jobs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,7 @@ MOCK_MODULES = [
     "notmuch",
     "requests",
     "bs4",
-    "novaclient.v2",
-    "psutil", "getpass"
+    "novaclient.v2"
 ]
 
 for mod_name in MOCK_MODULES:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ MOCK_MODULES = [
     "requests",
     "bs4",
     "novaclient.v2",
-    "dota2py",
+    "psutil", "getpass"
 ]
 
 for mod_name in MOCK_MODULES:

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -52,7 +52,8 @@ The wording usually used goes like this:
 
 To allow automatic generation of the docs without having all
 requirements of every module installed mocks are used. To make this
-work simply add all modules you import to the ``MOCK_MODULES`` list in
-``docs/conf.py``. This needs to be the actual name of the imported
+work simply add all modules of dependencies (so no standard library modules
+or modules provided by i3pystatus) you import to the ``MOCK_MODULES``
+list in ``docs/conf.py``. This needs to be the actual name of the imported
 module, so for example if you have ``from somepkg.mod import AClass``,
 you need to add ``somepkg.mod`` to the list.

--- a/i3pystatus/mail/__init__.py
+++ b/i3pystatus/mail/__init__.py
@@ -6,8 +6,7 @@ class Backend(SettingsBase):
     """Handles the details of checking for mail"""
 
     unread = 0
-    settings = ("account", "Account name")
-    # required = ("account", )
+    settings = (("account", "Account name"),)
 
     account = "Default account"
 

--- a/i3pystatus/makewatch.py
+++ b/i3pystatus/makewatch.py
@@ -13,7 +13,7 @@ class MakeWatch(IntervalModule):
         ("name", "Listen for a job other than 'make' jobs"),
         ("running_color", "Text color while the job is running"),
         ("idle_color", "Text color while the job is not running"),
-        "format", "idle_format"
+        "format",
     )
     running_color = "#FF0000"  # red
     idle_color = "#00FF00"   # green

--- a/i3pystatus/makewatch.py
+++ b/i3pystatus/makewatch.py
@@ -10,7 +10,6 @@ class MakeWatch(IntervalModule):
     """
 
     settings = (
-        ("user", "Specifies which user to track. Null means all users"),
         ("name", "Listen for a job other than 'make' jobs"),
         ("running_color", "Text color while the job is running"),
         ("idle_color", "Text color while the job is not running"),

--- a/i3pystatus/makewatch.py
+++ b/i3pystatus/makewatch.py
@@ -1,0 +1,45 @@
+from i3pystatus import IntervalModule
+import psutil
+import getpass
+
+
+class MakeWatch(IntervalModule):
+    """
+    Watches for make jobs and notifies when they are completed.
+    requires: psutil
+    """
+
+    settings = (
+        ("user", "Specifies which user to track. Null means all users"),
+        ("name", "Listen for a job other than 'make' jobs"),
+        ("running_color", "Text color while the job is running"),
+        ("idle_color", "Text color while the job is not running"),
+        "format", "idle_format"
+    )
+    running_color = "#FF0000"  # red
+    idle_color = "#00FF00"   # green
+    name = 'make'
+    format = "{name}: {status}"
+
+    def run(self):
+        status = 'idle'
+        for proc in psutil.process_iter():
+            cur_proc = proc.as_dict(attrs=['name', 'username'])
+            if getpass.getuser() in cur_proc['username']:
+                if cur_proc['name'] == self.name:
+                    status = proc.as_dict(attrs=['status'])['status']
+
+        if status == 'idle':
+            color = self.idle_color
+        else:
+            color = self.running_color
+
+        cdict = {
+            "name": self.name,
+            "status": status
+        }
+
+        self.output = {
+            "full_text": self.format.format(**cdict),
+            "color": color
+        }

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -20,7 +20,8 @@ class Openstack_vms(IntervalModule):
         ("crit_color", "Display color when non-active VMs are => `threshold`"),
         ("threshold", "Set critical indicators when non-active VM pass this "
             "number"),
-        ("horizon_url", "When clicked, open this URL in a browser")
+        ("horizon_url", "When clicked, open this URL in a browser"),
+        "format"
     )
     required = ("auth_url", "password", "tenant_name", "username")
     color = "#00FF00"

--- a/i3pystatus/parcel.py
+++ b/i3pystatus/parcel.py
@@ -150,7 +150,7 @@ class ParcelTracker(IntervalModule):
         "format",
         "name",
     )
-    required = ("instance",)
+    required = ("instance", "name")
 
     format = "{name}:{progress}"
     on_leftclick = "open_browser"

--- a/i3pystatus/pomodoro.py
+++ b/i3pystatus/pomodoro.py
@@ -30,6 +30,7 @@ class Pomodoro(IntervalModule):
         ('format', 'format string, available formatters: current_pomodoro, '
                    'total_pomodoro, time')
     )
+    required = ('sound',)
 
     color_stopped = '#2ECCFA'
     color_running = '#FFFF00'


### PR DESCRIPTION
A module that will watch for (by default) make jobs and notify of their
status.  This can be used for other long-running processes by providing
an alternate 'name'.