### PR TITLE
Add total received/sent Mbytes to network module

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -200,11 +200,11 @@ class NetworkTraffic():
 
     def get_rx_tot_Mbytes(self, interface):
         with open("/sys/class/net/{}/statistics/rx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0])/(1024*1024)
+            return int(f.readline().split('\n')[0])/(1024 * 1024)
 
     def get_tx_tot_Mbytes(self, interface):
         with open("/sys/class/net/{}/statistics/tx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0])/(1024*1024)
+            return int(f.readline().split('\n')[0])/(1024 * 1024)
 
     def get_usage(self, interface):
         self.update_counters(interface)
@@ -259,8 +259,8 @@ class Network(IntervalModule, ColorRangeModule):
     * `{bytes_recv}` — bytes received per second (divided by divisor)
     * `{packets_sent}` — bytes sent per second (divided by divisor)
     * `{packets_recv}` — bytes received per second (divided by divisor)
-    ^ `{rx_tot_Mbytes}` — total Mbytes received
-    ^ `{tx_tot_Mbytes}` — total Mbytes sent
+    * `{rx_tot_Mbytes}` — total Mbytes received
+    * `{tx_tot_Mbytes}` — total Mbytes sent
     """
     settings = (
         ("format_up", "format string"),

--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -200,11 +200,11 @@ class NetworkTraffic():
 
     def get_rx_tot_Mbytes(self, interface):
         with open("/sys/class/net/{}/statistics/rx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0])/(1024 * 1024)
+            return int(f.readline().split('\n')[0]) / (1024 * 1024)
 
     def get_tx_tot_Mbytes(self, interface):
         with open("/sys/class/net/{}/statistics/tx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0])/(1024 * 1024)
+            return int(f.readline().split('\n')[0]) / (1024 * 1024)
 
     def get_usage(self, interface):
         self.update_counters(interface)

--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -199,12 +199,18 @@ class NetworkTraffic():
         return self.pnic.packets_recv - self.pnic_before.packets_recv
 
     def get_rx_tot_Mbytes(self, interface):
-        with open("/sys/class/net/{}/statistics/rx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0]) / (1024 * 1024)
+        try:
+            with open("/sys/class/net/{}/statistics/rx_bytes".format(interface)) as f:
+                return int(f.readline().split('\n')[0]) / (1024 * 1024)
+        except FileNotFoundError:
+            return False
 
     def get_tx_tot_Mbytes(self, interface):
-        with open("/sys/class/net/{}/statistics/tx_bytes".format(interface)) as f:
-            return int(f.readline().split('\n')[0]) / (1024 * 1024)
+        try:
+            with open("/sys/class/net/{}/statistics/tx_bytes".format(interface)) as f:
+                return int(f.readline().split('\n')[0]) / (1024 * 1024)
+        except FileNotFoundError:
+            return False
 
     def get_usage(self, interface):
         self.update_counters(interface)

--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -198,6 +198,14 @@ class NetworkTraffic():
     def get_packets_received(self):
         return self.pnic.packets_recv - self.pnic_before.packets_recv
 
+    def get_rx_tot_Mbytes(self, interface):
+        with open("/sys/class/net/{}/statistics/rx_bytes".format(interface)) as f:
+            return int(f.readline().split('\n')[0])/(1024*1024)
+
+    def get_tx_tot_Mbytes(self, interface):
+        with open("/sys/class/net/{}/statistics/tx_bytes".format(interface)) as f:
+            return int(f.readline().split('\n')[0])/(1024*1024)
+
     def get_usage(self, interface):
         self.update_counters(interface)
         usage = dict(bytes_sent=0, bytes_recv=0, packets_sent=0, packets_recv=0)
@@ -209,6 +217,8 @@ class NetworkTraffic():
             usage["bytes_recv"] = self.get_bytes_received()
             usage["packets_sent"] = self.get_packets_sent()
             usage["packets_recv"] = self.get_packets_received()
+            usage["rx_tot_Mbytes"] = self.get_rx_tot_Mbytes(interface)
+            usage["tx_tot_Mbytes"] = self.get_tx_tot_Mbytes(interface)
             round_dict(usage, self.round_size)
         return usage
 
@@ -249,6 +259,8 @@ class Network(IntervalModule, ColorRangeModule):
     * `{bytes_recv}` — bytes received per second (divided by divisor)
     * `{packets_sent}` — bytes sent per second (divided by divisor)
     * `{packets_recv}` — bytes received per second (divided by divisor)
+    ^ `{rx_tot_Mbytes}` — total Mbytes received
+    ^ `{tx_tot_Mbytes}` — total Mbytes sent
     """
     settings = (
         ("format_up", "format string"),
@@ -313,7 +325,8 @@ class Network(IntervalModule, ColorRangeModule):
 
         # Don't require importing psutil unless using the functionality it offers.
         if any(s in self.format_up or s in self.format_down for s in
-               ['bytes_sent', 'bytes_recv', 'packets_sent', 'packets_recv', 'network_graph', 'kbs']):
+               ['bytes_sent', 'bytes_recv', 'packets_sent', 'packets_recv', 'network_graph',
+                'rx_tot_Mbytes', 'tx_tot_Mbytes', 'kbs']):
             self.network_traffic = NetworkTraffic(self.unknown_up, self.divisor, self.round_size)
         else:
             self.network_traffic = None
@@ -343,6 +356,7 @@ class Network(IntervalModule, ColorRangeModule):
 
     def run(self):
         format_values = dict(kbs="", network_graph="", bytes_sent="", bytes_recv="", packets_sent="", packets_recv="",
+                             rx_tot_Mbytes="", tx_tot_Mbytes="",
                              interface="", v4="", v4mask="", v4cidr="", v6="", v6mask="", v6cidr="", mac="",
                              essid="", freq="", quality="", quality_bar="")
         if self.network_traffic:


### PR DESCRIPTION
This very simple feature is implemented by reading the value of the total received/sent bytes in the files `/sys/class/net/{}/statistics/rx_bytes` and `/sys/class/net/{}/statistics/tx_bytes` for the designated interface and convert them into MBytes.