### PR TITLE
Dota2stats

### DIFF
--- a/i3pystatus/dota2wins.py
+++ b/i3pystatus/dota2wins.py
@@ -96,7 +96,7 @@ class Dota2wins(IntervalModule):
             "screenname": screenname,
             "wins": wins,
             "losses": losses,
-            "win_percent": win_percent,
+            "win_percent": "%.2f" % win_percent,
         }
 
         self.output = {


### PR DESCRIPTION
In order to avoid filling i3pystatus with super long decimals, this
patch sets the dota2win module to use only 2 decimal places for it's win
percent.
