### PR TITLE
Bar refresh

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -298,3 +298,6 @@ The settings can be of different types, namely
   elements are passed as arguments to the callable
 - again a special case of the above: just a callable, no parameters
 - a string which is run in a shell
+
+.. note:: If you want to simply refresh the output of a module by clicking on
+  it, set desired callback to ``"run"`` e.g. ``on_leftclick = "run"``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -370,3 +370,31 @@ Or make two modules look like one.
             hints = {"separator": False, "separator_block_width": 0},
             text = "Antidisestabli",
             color="#FF0000")
+
+.. _refresh:
+
+Refreshing the bar
+------------------
+
+The whole bar can be refreshed by sending SIGUSR1 signal to i3pystatus process.
+
+To find the PID of the i3pystatus process look for the ``status_command`` you
+use in your i3 config file.
+If your `bar` section of i3 config looks like this
+
+    .. code::
+
+        bar {
+            status_command python ~/.config/i3/pystatus.py
+        }
+
+then you can refresh the bar by using the following command:
+
+    .. code:: bash
+
+        pkill -SIGUSR1 -f "python /home/user/.config/i3/pystatus.py"
+
+Note that the path must be expanded.
+
+.. note:: If you use slow modules in your bar (like :py:class:`.Updates`) which
+  take some time to update, the refresh of the whole bar may be delayed.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -377,6 +377,7 @@ Refreshing the bar
 ------------------
 
 The whole bar can be refreshed by sending SIGUSR1 signal to i3pystatus process.
+This feature is available only in standalone :py:class:`.Status` operation.
 
 To find the PID of the i3pystatus process look for the ``status_command`` you
 use in your i3 config file.

--- a/i3pystatus/bitcoin.py
+++ b/i3pystatus/bitcoin.py
@@ -126,4 +126,4 @@ class Bitcoin(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()

--- a/i3pystatus/bitcoin.py
+++ b/i3pystatus/bitcoin.py
@@ -124,3 +124,6 @@ class Bitcoin(IntervalModule):
             "full_text": self.format.format(**fdict),
             "color": color,
         }
+
+    def on_refresh(self):
+        self._background_refresh()

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -32,7 +32,7 @@ class CommandEndpoint:
         for command in self.io_handler_factory().read():
             target_module = self.modules.get(command["instance"])
             if target_module and target_module.on_click(command["button"]):
-                target_module.run()
+                target_module.on_refresh()
                 os.kill(os.getpid(), signal.SIGUSR2)
 
 

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -31,8 +31,7 @@ class CommandEndpoint:
     def _command_endpoint(self):
         for command in self.io_handler_factory().read():
             target_module = self.modules.get(command["instance"])
-            if target_module:
-                target_module.on_click(command["button"])
+            if target_module and target_module.on_click(command["button"]):
                 target_module.run()
                 os.kill(os.getpid(), signal.SIGUSR2)
 

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -33,7 +33,7 @@ class CommandEndpoint:
             target_module = self.modules.get(command["instance"])
             if target_module and target_module.on_click(command["button"]):
                 target_module.on_refresh()
-                io.StandaloneIO.register_click_event()
+                io.StandaloneIO.refresh_statusline()
 
 
 class Status:

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -33,7 +33,8 @@ class CommandEndpoint:
             target_module = self.modules.get(command["instance"])
             if target_module:
                 target_module.on_click(command["button"])
-
+                target_module.run()
+                os.kill(os.getpid(), signal.SIGUSR1)
 
 
 class Status:

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -34,7 +34,7 @@ class CommandEndpoint:
             if target_module:
                 target_module.on_click(command["button"])
                 target_module.run()
-                os.kill(os.getpid(), signal.SIGUSR1)
+                os.kill(os.getpid(), signal.SIGUSR2)
 
 
 class Status:
@@ -55,14 +55,16 @@ class Status:
             def no_op(signum, stack):
                 return
             signal.signal(signal.SIGUSR1, no_op)
+            signal.signal(signal.SIGUSR2, no_op)
 
-            self.io = io.StandaloneIO(self.click_events, interval)
+            self.io = io.StandaloneIO(self.click_events, self.modules, interval)
             if self.click_events:
                 self.command_endpoint = CommandEndpoint(
                     self.modules,
                     lambda: io.JSONIO(io=io.IOHandler(sys.stdin, open(os.devnull, "w")), skiplines=1))
         else:
             signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+            signal.signal(signal.SIGUSR2, signal.SIG_IGN)
             self.io = io.IOHandler(input_stream)
 
     def register(self, module, *args, **kwargs):

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -33,7 +33,7 @@ class CommandEndpoint:
             target_module = self.modules.get(command["instance"])
             if target_module and target_module.on_click(command["button"]):
                 target_module.on_refresh()
-                os.kill(os.getpid(), signal.SIGUSR2)
+                io.StandaloneIO.register_click_event()
 
 
 class Status:
@@ -54,7 +54,6 @@ class Status:
             def no_op(signum, stack):
                 return
             signal.signal(signal.SIGUSR1, no_op)
-            signal.signal(signal.SIGUSR2, no_op)
 
             self.io = io.StandaloneIO(self.click_events, self.modules, interval)
             if self.click_events:
@@ -63,7 +62,6 @@ class Status:
                     lambda: io.JSONIO(io=io.IOHandler(sys.stdin, open(os.devnull, "w")), skiplines=1))
         else:
             signal.signal(signal.SIGUSR1, signal.SIG_IGN)
-            signal.signal(signal.SIGUSR2, signal.SIG_IGN)
             self.io = io.IOHandler(input_stream)
 
     def register(self, module, *args, **kwargs):

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -1,10 +1,12 @@
-import sys
 import os
+import signal
+import sys
 from threading import Thread
-from i3pystatus.core.exceptions import ConfigError
 
+from i3pystatus.core import io
+from i3pystatus.core import util
+from i3pystatus.core.exceptions import ConfigError
 from i3pystatus.core.imputil import ClassFinder
-from i3pystatus.core import io, util
 from i3pystatus.core.modules import Module
 
 
@@ -33,6 +35,7 @@ class CommandEndpoint:
                 target_module.on_click(command["button"])
 
 
+
 class Status:
     """
     The main class used for registering modules and managing I/O
@@ -48,12 +51,17 @@ class Status:
         self.standalone = standalone
         self.click_events = click_events
         if standalone:
+            def no_op(signum, stack):
+                return
+            signal.signal(signal.SIGUSR1, no_op)
+
             self.io = io.StandaloneIO(self.click_events, interval)
             if self.click_events:
                 self.command_endpoint = CommandEndpoint(
                     self.modules,
                     lambda: io.JSONIO(io=io.IOHandler(sys.stdin, open(os.devnull, "w")), skiplines=1))
         else:
+            signal.signal(signal.SIGUSR1, signal.SIG_IGN)
             self.io = io.IOHandler(input_stream)
 
     def register(self, module, *args, **kwargs):

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -52,7 +52,7 @@ class StandaloneIO(IOHandler):
     and the i3bar protocol header
     """
 
-    __is_click_event = False
+    refresh_modules = True
 
     n = -1
     proto = [
@@ -77,11 +77,15 @@ class StandaloneIO(IOHandler):
                 return
 
             if received_signal:
-                if StandaloneIO.__is_click_event:
-                    StandaloneIO.__is_click_event = False
-                else:
+                if StandaloneIO.refresh_modules:
+                    # refresh whole bar
                     for module in self.modules:
                         module.on_refresh()
+                else:
+                    # just send status line to i3bar immediately -> do nothing here
+
+                    # set next signal action back to default
+                    StandaloneIO.refresh_modules = True
 
             yield self.read_line()
 
@@ -91,8 +95,12 @@ class StandaloneIO(IOHandler):
         return self.proto[min(self.n, len(self.proto) - 1)]
 
     @classmethod
-    def register_click_event(cls):
-        cls.__is_click_event = True
+    def refresh_statusline(cls):
+        """
+        Changes behavior of the next SIGUSR1 signal to just flushing current
+        outputs of all modules and sends the signal.
+        """
+        cls.refresh_modules = False
         os.kill(os.getpid(), signal.SIGUSR1)
 
 

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -65,17 +65,19 @@ class StandaloneIO(IOHandler):
 
     def read(self):
         while True:
+            info = None
             try:
                 info = signal.sigtimedwait([signal.SIGUSR1, signal.SIGUSR2],
                                            self.interval)
-                # refresh the whole bar
-                if info and info.si_signo == signal.SIGUSR1:
-                    for module in self.modules:
-                        module.run()
             except InterruptedError:
                 logging.getLogger("i3pystatus").exception("Interrupted system call:")
             except KeyboardInterrupt:
                 return
+
+            # refresh the whole bar
+            if info and info.si_signo == signal.SIGUSR1:
+                for module in self.modules:
+                    module.on_refresh()
 
             yield self.read_line()
 

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -96,7 +96,6 @@ class StandaloneIO(IOHandler):
         os.kill(os.getpid(), signal.SIGUSR1)
 
 
-
 class JSONIO:
     def __init__(self, io, skiplines=2):
         self.io = io

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import signal
 import sys
 from contextlib import contextmanager
@@ -66,7 +67,7 @@ class StandaloneIO(IOHandler):
             try:
                 signal.sigtimedwait([signal.SIGUSR1], self.interval)
             except InterruptedError:
-                pass
+                logging.getLogger("i3pystatus").exception("Interrupted system call:")
             except KeyboardInterrupt:
                 return
 

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -65,6 +65,8 @@ class StandaloneIO(IOHandler):
         while True:
             try:
                 signal.sigtimedwait([signal.SIGUSR1], self.interval)
+            except InterruptedError:
+                pass
             except KeyboardInterrupt:
                 return
 

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -1,5 +1,5 @@
-import time
 import json
+import signal
 import sys
 from contextlib import contextmanager
 
@@ -64,7 +64,7 @@ class StandaloneIO(IOHandler):
     def read(self):
         while True:
             try:
-                time.sleep(self.interval)
+                signal.sigtimedwait([signal.SIGUSR1], self.interval)
             except KeyboardInterrupt:
                 return
 

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -128,6 +128,22 @@ class Module(SettingsBase):
             out = self.output["short_text"].replace("&", "&amp;")
             self.output.update({"short_text": out})
 
+    def _background_refresh(self):
+        if getattr(self, "_refresh_thread", None) is None:
+            self._refresh_thread = None
+
+        # check if previous refresh is done
+        if self._refresh_thread and not self._refresh_thread.is_alive():
+            self._refresh_thread = None
+
+        if not self._refresh_thread:
+            def refresh_job(module):
+                module.run()
+                kill(getpid(), SIGUSR2)
+
+            self._refresh_thread = Thread(target=refresh_job, args=(self,))
+            self._refresh_thread.start()
+
 
 class IntervalModule(Module):
     settings = (

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -109,6 +109,9 @@ class Module(SettingsBase):
             run_through_shell(cb, *args)
         return True
 
+    def on_refresh(self):
+        self.run()
+
     def move(self, position):
         self.position = position
         return self

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -81,21 +81,23 @@ class Module(SettingsBase):
             cb = self.on_downscroll
         else:
             self.logger.info("Button '%d' not handled yet." % (button))
-            return
+            return False
 
         if not cb:
             self.logger.info("no cb attached")
-            return
+            return False
         else:
             cb, args = split_callback_and_args(cb)
             self.logger.debug("cb=%s args=%s" % (cb, args))
 
         if callable(cb):
-            return cb(self)
+            cb(self)
         elif hasattr(self, cb):
-            return getattr(self, cb)(*args)
+            if cb is not "run":
+                getattr(self, cb)(*args)
         else:
-            return run_through_shell(cb, *args)
+            run_through_shell(cb, *args)
+        return True
 
     def move(self, position):
         self.position = position

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -124,12 +124,20 @@ class Module(SettingsBase):
         Replaces all ampersands in `"full_text"` and `"short_text"` blocks` in
         `self.output` with `&amp;`.
         """
+        def replace(s):
+            s = s.split("&")
+            out = s[0]
+            for i in range(len(s) - 1):
+                if s[i + 1].startswith("amp;"):
+                    out += "&" + s[i + 1]
+                else:
+                    out += "&amp;" + s[i + 1]
+            return out
+
         if "full_text" in self.output.keys():
-            out = self.output["full_text"].replace("&", "&amp;")
-            self.output.update({"full_text": out})
+            self.output["full_text"] = replace(self.output["full_text"])
         if "short_text" in self.output.keys():
-            out = self.output["short_text"].replace("&", "&amp;")
-            self.output.update({"short_text": out})
+            self.output["short_text"] = replace(self.output["short_text"])
 
     def _background_refresh(self):
         if getattr(self, "_refresh_thread", None) is None:

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -38,7 +38,7 @@ class Module(SettingsBase):
                     if key not in self.output:
                         self.output.update({key: val})
             if self.output.get("markup") == "pango":
-                self.__text_to_pango()
+                self._text_to_pango()
 
             json.insert(convert_position(self.position, json), self.output)
 
@@ -116,7 +116,7 @@ class Module(SettingsBase):
         self.position = position
         return self
 
-    def __text_to_pango(self):
+    def _text_to_pango(self):
         """
         Replaces all ampersands in `"full_text"` and `"short_text"` blocks` in
         `self.output` with `&amp;`.

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -1,3 +1,6 @@
+import threading
+
+from i3pystatus.core.io import StandaloneIO
 from i3pystatus.core.settings import SettingsBase
 from i3pystatus.core.threading import Manager
 from i3pystatus.core.util import convert_position
@@ -139,9 +142,9 @@ class Module(SettingsBase):
         if not self._refresh_thread:
             def refresh_job(module):
                 module.run()
-                kill(getpid(), SIGUSR2)
+                StandaloneIO.register_click_event()
 
-            self._refresh_thread = Thread(target=refresh_job, args=(self,))
+            self._refresh_thread = threading.Thread(target=refresh_job, args=(self,))
             self._refresh_thread.start()
 
 

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -61,3 +61,6 @@ class Github(IntervalModule):
             'full_text': self.format.format(**format_values),
             'color': self.color
         }
+
+    def on_refresh(self):
+        self._background_refresh()

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -63,4 +63,4 @@ class Github(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()

--- a/i3pystatus/mail/__init__.py
+++ b/i3pystatus/mail/__init__.py
@@ -86,6 +86,9 @@ class Mail(IntervalModule):
             "color": color,
         }
 
+    def on_refresh(self):
+        self._background_refresh()
+
     def scroll_backend(self, step):
         self.current_backend = (self.current_backend + step) % len(self.backends)
 

--- a/i3pystatus/mail/__init__.py
+++ b/i3pystatus/mail/__init__.py
@@ -87,7 +87,7 @@ class Mail(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()
 
     def scroll_backend(self, step):
         self.current_backend = (self.current_backend + step) % len(self.backends)

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -116,4 +116,3 @@ class NetSpeed(IntervalModule):
 
     def on_refresh(self):
         self._background_refresh()
-

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -1,12 +1,15 @@
-from i3pystatus import IntervalModule
-import speedtest_cli
-import requests
-import time
-import os
-from urllib.parse import urlparse
 import contextlib
+import os
+import requests
+import speedtest_cli
 import sys
+import time
 from io import StringIO
+from urllib.parse import urlparse
+
+from i3pystatus import IntervalModule
+from i3pystatus.core.util import internet
+from i3pystatus.core.util import require
 
 
 class NetSpeed(IntervalModule):
@@ -27,6 +30,7 @@ class NetSpeed(IntervalModule):
     units = 'bits'
     format = "{speed} ({hosting_provider})"
 
+    @require(internet)
     def run(self):
 
         # since speedtest_cli likes to print crap, we need to squelch it
@@ -109,3 +113,7 @@ class NetSpeed(IntervalModule):
             "full_text": self.format.format(**cdict),
             "color": self.color
         }
+
+    def on_refresh(self):
+        self._background_refresh()
+

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -115,4 +115,4 @@ class NetSpeed(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()

--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -397,3 +397,6 @@ class Network(IntervalModule, ColorRangeModule):
             "full_text": format_str.format(**format_values),
             'color': color,
         }
+
+    def on_refresh(self):
+        return

--- a/i3pystatus/parcel.py
+++ b/i3pystatus/parcel.py
@@ -167,5 +167,9 @@ class ParcelTracker(IntervalModule):
             "instance": self.name,
         }
 
+    def on_refresh(self):
+        self._background_refresh()
+
+
     def open_browser(self):
         webbrowser.open_new_tab(self.instance.get_url())

--- a/i3pystatus/parcel.py
+++ b/i3pystatus/parcel.py
@@ -168,7 +168,7 @@ class ParcelTracker(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()
 
     def open_browser(self):
         webbrowser.open_new_tab(self.instance.get_url())

--- a/i3pystatus/parcel.py
+++ b/i3pystatus/parcel.py
@@ -170,6 +170,5 @@ class ParcelTracker(IntervalModule):
     def on_refresh(self):
         self._background_refresh()
 
-
     def open_browser(self):
         webbrowser.open_new_tab(self.instance.get_url())

--- a/i3pystatus/reddit.py
+++ b/i3pystatus/reddit.py
@@ -137,6 +137,9 @@ class Reddit(IntervalModule):
             "color": color,
         }
 
+    def on_refresh(self):
+        self._background_refresh()
+
     def open_mail(self):
         user_open('https://www.reddit.com/message/unread/')
 

--- a/i3pystatus/reddit.py
+++ b/i3pystatus/reddit.py
@@ -138,7 +138,7 @@ class Reddit(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()
 
     def open_mail(self):
         user_open('https://www.reddit.com/message/unread/')

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -58,7 +58,7 @@ class Updates(IntervalModule):
     color = "#00DD00"
     color_no_updates = "#FFFFFF"
 
-    on_leftclick = "refresh"
+    on_leftclick = "run"
 
     def init(self):
         if not isinstance(self.backends, list):
@@ -84,7 +84,3 @@ class Updates(IntervalModule):
             "full_text": formatp(self.format, **fdict).strip(),
             "color": self.color,
         }
-
-    def refresh(self):
-        # Dummy callback to enable click event.
-        return

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -89,4 +89,4 @@ class Updates(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -1,5 +1,8 @@
-from i3pystatus import SettingsBase, IntervalModule, formatp
-from i3pystatus.core.util import internet, require
+from i3pystatus import formatp
+from i3pystatus import IntervalModule
+from i3pystatus import SettingsBase
+from i3pystatus.core.util import internet
+from i3pystatus.core.util import require
 
 
 class Backend(SettingsBase):
@@ -84,3 +87,6 @@ class Updates(IntervalModule):
             "full_text": formatp(self.format, **fdict).strip(),
             "color": self.color,
         }
+
+    def on_refresh(self):
+        self._background_refresh()

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -58,7 +58,7 @@ class Updates(IntervalModule):
     color = "#00DD00"
     color_no_updates = "#FFFFFF"
 
-    on_leftclick = "run"
+    on_leftclick = "refresh"
 
     def init(self):
         if not isinstance(self.backends, list):
@@ -84,3 +84,7 @@ class Updates(IntervalModule):
             "full_text": formatp(self.format, **fdict).strip(),
             "color": self.color,
         }
+
+    def refresh(self):
+        # Dummy callback to enable click event.
+        return

--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -114,4 +114,3 @@ class Weather(IntervalModule):
 
     def on_refresh(self):
         self._background_refresh()
-

--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -111,3 +111,7 @@ class Weather(IntervalModule):
             ),
             "color": color
         }
+
+    def on_refresh(self):
+        self._background_refresh()
+

--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -113,4 +113,4 @@ class Weather(IntervalModule):
         }
 
     def on_refresh(self):
-        self._background_refresh()
+        self.background_refresh()


### PR DESCRIPTION
This PR implements features from #155.
* The whole statusline is refreshed if SIGUSR1 is recieved.
* After every click event with valid callback, modules output is refreshed by calling ``run`` and updated statusline is sent to i3bar.

Standalone operation is required for this features.

SIGUSR2 is used internally for click events. Recieving it flushes current state to i3bar immediately.

Now I am just wondering if it'll actually work fine with anyone else's config files.

Edit: Maybe adding option to disable specific module from refreshing could be useful?