### PR TITLE
Added proper formatter for uptime module

### DIFF
--- a/i3pystatus/uptime.py
+++ b/i3pystatus/uptime.py
@@ -1,11 +1,18 @@
 
 from i3pystatus import IntervalModule, formatp
-from i3pystatus.core.util import TimeWrapper
 
 
 class Uptime(IntervalModule):
     """
     Outputs Uptime
+
+    .. rubric:: Available formatters
+
+    * `{days}` - uptime in days
+    * `{hours}` - rest of uptime in hours
+    * `{mins}` - rest of uptime in minutes
+    * `{secs}` - rest of uptime in seconds
+    * `{uptime}` - deprecated: equals '`{hours}:{mins}`'
     """
 
     settings = (
@@ -17,18 +24,36 @@ class Uptime(IntervalModule):
     )
 
     file = "/proc/uptime"
-    format = "up {uptime}"
+    format = "up {hours}:{mins}"
     color = "#ffffff"
     alert = False
-    seconds_alert = 3600
+    seconds_alert = 60 * 60 * 24 * 30  # 30 days
     color_alert = "#ff0000"
 
     def run(self):
         with open(self.file, "r") as f:
-            seconds = float(f.read().split()[0])
-            fdict = {
-                "uptime": TimeWrapper(seconds, "%h:%m"),
-            }
+            seconds = int(float(f.read().split()[0]))
+
+        days = seconds // (60 * 60 * 24)
+        hours = seconds // (60 * 60)
+        minutes = seconds // 60
+        if "{days}" in self.format:
+            hours = (seconds % (60 * 60 * 24)) // (60 * 60)
+            minutes = (seconds % (60 * 60 * 24)) // 60
+            seconds = (seconds % (60 * 60 * 24))
+        if "{hours}" in self.format:
+            minutes = (seconds % (60 * 60)) // 60
+            seconds = (seconds % (60 * 60))
+        if "{mins}" in self.format:
+            seconds = seconds % 60
+
+        fdict = {
+            "days": days,
+            "hours": hours,
+            "mins": minutes,
+            "secs": seconds,
+            "uptime": "{}:{}".format(hours, minutes),
+        }
 
         if self.alert:
             if seconds > self.seconds_alert:


### PR DESCRIPTION
Added a proper formatter for uptime. You can now choose between days, hours, minutes and seconds. I removed the TimeWrapper, because it was not possible to display days with it.
Changes are downwards compatible, because the previous `{uptime}` formatter works like before. So nobody is forced to change the config file.