### PR TITLE
Fix documentation & code for launching external programs from callbacks

### DIFF
--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -27,7 +27,9 @@ def run_through_shell(command, enable_shell=False):
     except OSError as e:
         out = e.strerror
         stderr = e.strerror
+        returncode = 1
     except subprocess.CalledProcessError as e:
         out = e.output
+        returncode = 1
 
     return CommandResult(returncode, out, stderr)


### PR DESCRIPTION
This commit fixes callbacks (on_leftclick) to external program that accept additionnal parameters.

For instance it is now possible to set this callback:
on_leftclick=["/usr/bin/urxvtc",'-e', 'ikhal']

I've also improved the debugging messages in case of errors and
documented this usage.

1 remark:
- I wanted to put the name of the module in the debug statement: is
  self.__name__ correct or is it anything better ?