### PR TITLE
Cmus improved

### DIFF
--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -52,19 +52,20 @@ class Cmus(IntervalModule):
         return run_through_shell(cmdline, enable_shell=True)
 
     def _query_cmus(self):
-        status_dict = {}
+        response = {}
         cmd = self._cmus_command('query')
+
         if not cmd.rc:
-            status = cmd.out.split('\n')
-            for item in status:
-                split_item = item.split(' ')
-                if split_item[0] in ['tag', 'set']:
-                    key = '_'.join(split_item[:2])
-                    val = ' '.join([x for x in split_item[2:]])
-                    status_dict[key] = val
+            for line in cmd.out.splitlines():
+                category, _, category_value = line.partition(' ')
+                if category in ('set', 'tag'):
+                    key, _, value = category_value.partition(' ')
+                    key = '_'.join((category, key))
+                    response[key] = value
                 else:
-                    status_dict[split_item[0]] = ' '.join(split_item[1:])
-        return status_dict
+                    response[category] = category_value
+
+        return response
 
     def run(self):
         status = self._query_cmus()

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -1,6 +1,7 @@
 import os
 
-from i3pystatus import IntervalModule, formatp
+from i3pystatus import formatp
+from i3pystatus import IntervalModule
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.core.util import TimeWrapper
 

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -37,8 +37,8 @@ class Cmus(IntervalModule):
         ('status', 'Dictionary mapping status to output'),
     )
 
-    color = '#909090'
-    color_not_running = '#909090'
+    color = '#ffffff'
+    color_not_running = '#ffffff'
     format = '{status} {song_elapsed}/{song_length} {artist} - {title}'
     format_not_running = 'Not running'
     interval = 1

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -73,8 +73,7 @@ class Cmus(IntervalModule):
 
     def run(self):
         self.output = {
-            'full_text': self.format_not_running,
-            'color': self.color
+            'color': self.color,
         }
         response = self._query_cmus()
 
@@ -100,6 +99,8 @@ class Cmus(IntervalModule):
                 fdict['artist'], fdict['title'] = _extract_artist_title(filebase)
 
             self.output['full_text'] = formatp(self.format, **fdict)
+        else:
+            self.output['full_text'] = self.format_not_running
 
     def playpause(self):
         status = self._query_cmus().get('status', '')

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -31,12 +31,14 @@ class Cmus(IntervalModule):
 
     settings = (
         ('format', 'formatp string'),
+        ('format_not_running', 'Text to show if cmus is not running'),
         ('color', 'The color of the text'),
         ('status', 'Dictionary mapping status to output'),
     )
 
     color = '#909090'
     format = '{status} {song_elapsed}/{song_length} {artist} - {title}'
+    format_not_running = 'Not running'
     interval = 1
     status = {
         'paused': '▷',
@@ -71,7 +73,7 @@ class Cmus(IntervalModule):
 
     def run(self):
         self.output = {
-            'full_text': 'Not running',
+            'full_text': self.format_not_running,
             'color': self.color
         }
         response = self._query_cmus()

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -15,7 +15,6 @@ def _extract_artist_title(input):
 
 
 class Cmus(IntervalModule):
-
     """
     Gets the status and current song info using cmus-remote
 

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -32,9 +32,9 @@ class Cmus(IntervalModule):
         ('format', 'formatp string'),
         ('color', 'The color of the text'),
     )
+
     color = '#909090'
     format = '{status} {song_elapsed}/{song_length} {artist} - {title}'
-    status_text = ''
     interval = 1
     status = {
         'paused': '▷',

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -1,8 +1,8 @@
 import os
 
 from i3pystatus import IntervalModule, formatp
+from i3pystatus.core.command import run_through_shell
 from i3pystatus.core.util import TimeWrapper
-import subprocess
 
 
 def _extract_artist_title(input):
@@ -54,16 +54,14 @@ class Cmus(IntervalModule):
     on_downscroll = 'previous_song'
 
     def _cmus_command(self, command):
-        p = subprocess.Popen('cmus-remote --{command}'.format(command=command), shell=True,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT)
-        return p.communicate()
+        cmdline = 'cmus-remote --{command}'.format(command=command)
+        return run_through_shell(cmdline, enable_shell=True)
 
     def _query_cmus(self):
         status_dict = {}
-        status, error = self._cmus_command('query')
-        if status != b'cmus-remote: cmus is not running\n':
-            status = status.decode('utf-8').split('\n')
+        cmd = self._cmus_command('query')
+        if not cmd.rc:
+            status = cmd.out.split('\n')
             for item in status:
                 split_item = item.split(' ')
                 if split_item[0] in ['tag', 'set']:

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -6,12 +6,8 @@ from i3pystatus.core.util import TimeWrapper
 
 
 def _extract_artist_title(input):
-    for sep in ('-', ' - '):
-        split = input.split(sep)
-        if len(split) == 2:
-            return split[0], split[1]
-    # fallback
-    return (input.split('-') + [''] * 2)[:2]
+    artist, title = (input.split('-') + [''])[:2]
+    return artist.strip(), title.strip()
 
 
 class Cmus(IntervalModule):

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -33,10 +33,12 @@ class Cmus(IntervalModule):
         ('format', 'formatp string'),
         ('format_not_running', 'Text to show if cmus is not running'),
         ('color', 'The color of the text'),
+        ('color_not_running', 'The color of the text, when cmus is not running'),
         ('status', 'Dictionary mapping status to output'),
     )
 
     color = '#909090'
+    color_not_running = '#909090'
     format = '{status} {song_elapsed}/{song_length} {artist} - {title}'
     format_not_running = 'Not running'
     interval = 1
@@ -72,9 +74,7 @@ class Cmus(IntervalModule):
         return response
 
     def run(self):
-        self.output = {
-            'color': self.color,
-        }
+        self.output = {}
         response = self._query_cmus()
 
         if response:
@@ -99,8 +99,10 @@ class Cmus(IntervalModule):
                 fdict['artist'], fdict['title'] = _extract_artist_title(filebase)
 
             self.output['full_text'] = formatp(self.format, **fdict)
+            self.output['color'] = self.color
         else:
             self.output['full_text'] = self.format_not_running
+            self.output['color'] = self.color_not_running
 
     def playpause(self):
         status = self._query_cmus().get('status', '')

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -29,10 +29,8 @@ class Cmus(IntervalModule):
     """
 
     settings = (
-        ('format', 'format string, available formatters: status, song_elapsed, '
-                   'song_length, artist, title, album, tracknumber, file, '
-                   'stream, bitrate'),
-        'color',
+        ('format', 'formatp string'),
+        ('color', 'The color of the text'),
     )
     color = '#909090'
     format = '{status} {song_elapsed}/{song_length} {artist} - {title}'

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -39,20 +39,20 @@ class Cmus(IntervalModule):
                    'stream, bitrate'),
         'color',
     )
-    color = "#909090"
-    format = "{status} {song_elapsed}/{song_length} {artist} - {title}"
+    color = '#909090'
+    format = '{status} {song_elapsed}/{song_length} {artist} - {title}'
     status_text = ''
     interval = 1
     status = {
-        "paused": "▷",
-        "playing": "▶",
-        "stopped": "◾",
+        'paused': '▷',
+        'playing': '▶',
+        'stopped': '◾',
     }
 
-    on_leftclick = "playpause"
-    on_rightclick = "next_song"
-    on_upscroll = "next_song"
-    on_downscroll = "previous_song"
+    on_leftclick = 'playpause'
+    on_rightclick = 'next_song'
+    on_upscroll = 'next_song'
+    on_downscroll = 'previous_song'
 
     def _cmus_command(self, command):
         p = subprocess.Popen('cmus-remote --{command}'.format(command=command), shell=True,
@@ -79,13 +79,13 @@ class Cmus(IntervalModule):
         status = self._query_cmus()
         if not status:
             self.output = {
-                "full_text": 'Not running',
-                "color": self.color
+                'full_text': 'Not running',
+                'color': self.color
             }
             return
         fdict = {
             'file': status.get('file', ''),
-            'status': self.status[status["status"]],
+            'status': self.status[status['status']],
             'title': status.get('tag_title', ''),
             'stream': status.get('stream', ''),
             'album': status.get('tag_album', ''),
@@ -93,7 +93,7 @@ class Cmus(IntervalModule):
             'tracknumber': status.get('tag_tracknumber', 0),
             'song_length': TimeWrapper(status.get('duration', 0)),
             'song_elapsed': TimeWrapper(status.get('position', 0)),
-            'bitrate': int(status.get("bitrate", 0)),
+            'bitrate': int(status.get('bitrate', 0)),
         }
 
         if fdict['stream']:
@@ -109,8 +109,8 @@ class Cmus(IntervalModule):
         fdict['artist'] = fdict['artist'].strip()
 
         self.output = {
-            "full_text": formatp(self.format, **fdict),
-            "color": self.color
+            'full_text': formatp(self.format, **fdict),
+            'color': self.color
         }
 
     def playpause(self):
@@ -123,7 +123,7 @@ class Cmus(IntervalModule):
             self._cmus_command('play')
 
     def next_song(self):
-        self._cmus_command("next")
+        self._cmus_command('next')
 
     def previous_song(self):
-        self._cmus_command("prev")
+        self._cmus_command('prev')

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -32,6 +32,7 @@ class Cmus(IntervalModule):
     settings = (
         ('format', 'formatp string'),
         ('color', 'The color of the text'),
+        ('status', 'Dictionary mapping status to output'),
     )
 
     color = '#909090'

--- a/i3pystatus/cmus.py
+++ b/i3pystatus/cmus.py
@@ -68,42 +68,34 @@ class Cmus(IntervalModule):
         return response
 
     def run(self):
-        status = self._query_cmus()
-        if not status:
-            self.output = {
-                'full_text': 'Not running',
-                'color': self.color
-            }
-            return
-        fdict = {
-            'file': status.get('file', ''),
-            'status': self.status[status['status']],
-            'title': status.get('tag_title', ''),
-            'stream': status.get('stream', ''),
-            'album': status.get('tag_album', ''),
-            'artist': status.get('tag_artist', ''),
-            'tracknumber': status.get('tag_tracknumber', 0),
-            'song_length': TimeWrapper(status.get('duration', 0)),
-            'song_elapsed': TimeWrapper(status.get('position', 0)),
-            'bitrate': int(status.get('bitrate', 0)),
-        }
-
-        if fdict['stream']:
-            fdict['artist'], fdict[
-                'title'] = _extract_artist_title(fdict['stream'])
-
-        elif not fdict['title']:
-            _, filename = os.path.split(fdict['file'])
-            filebase, _ = os.path.splitext(filename)
-            fdict['artist'], fdict['title'] = _extract_artist_title(filebase)
-
-        fdict['title'] = fdict['title'].strip()
-        fdict['artist'] = fdict['artist'].strip()
-
         self.output = {
-            'full_text': formatp(self.format, **fdict),
+            'full_text': 'Not running',
             'color': self.color
         }
+        response = self._query_cmus()
+
+        if response:
+            fdict = {
+                'file': response.get('file', ''),
+                'status': self.status[response['status']],
+                'title': response.get('tag_title', ''),
+                'stream': response.get('stream', ''),
+                'album': response.get('tag_album', ''),
+                'artist': response.get('tag_artist', ''),
+                'tracknumber': response.get('tag_tracknumber', 0),
+                'song_length': TimeWrapper(response.get('duration', 0)),
+                'song_elapsed': TimeWrapper(response.get('position', 0)),
+                'bitrate': int(response.get('bitrate', 0)),
+            }
+
+            if fdict['stream']:
+                fdict['artist'], fdict['title'] = _extract_artist_title(fdict['stream'])
+            elif not fdict['title']:
+                filename = os.path.basename(fdict['file'])
+                filebase, _ = os.path.splitext(filename)
+                fdict['artist'], fdict['title'] = _extract_artist_title(filebase)
+
+            self.output['full_text'] = formatp(self.format, **fdict)
 
     def playpause(self):
         status = self._query_cmus().get('status', '')


### PR DESCRIPTION
This set of commits improve the cmus module. It is mostly code cleanup (consistent style, more "pythonic" code, removal of useless code paths) and exposing of the following settings:
- status: Mapping of status to output
- format_not_running: Text which is displayed when cmus is not running (closes #226) [new]
- color_not_running: Color of text when cmus is not running [new]