### PR TITLE
Move list of contributors into an extra files.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,67 @@
+aaron-lebo
+Alastair Houghton
+Alexis Lahouze
+Alex Timmermann
+Andrés Martano
+Argish42
+Armin Fisslthaler
+Arvedui
+Baptiste Grenier
+bparmentier
+Cezary Biele
+cganas
+Christopher Ganas
+Chris Wood
+David Foucher
+David Garcia Quintas
+David Wahlstrom
+dubwoc
+eBrnd
+enkore
+facetoe
+Frank Tackitt
+gacekjk
+Georg Sieber
+Goran Mekić
+Gordon Schulz
+Hugo Osvaldo Barrera
+Iliyas Jorio
+Ismael
+Ismael Puerto
+Jan Oliver Oelerich
+Jason Hite
+Joaquin Ignacio Barotto
+Jörg Thalheim
+Josef Gajdusek
+Júlio Rieger Lucchese
+Kenneth Lyons
+krypt-n
+Lukáš Mandák
+Łukasz Jędrzejewski
+Matthias Pronk
+Matthieu Coudron
+Matus Telgarsky
+Michael Schmidt
+microarm15
+Mikael Knutsson
+Naglis Jonaitis
+Pandada8
+Paul Bienkowski
+philipdexter
+Philip Dexter
+plumps
+Raphael Scholer
+Sergei Turukin
+Sergey Rublev
+siikamiika
+Simon
+Simon Legner
+Stéphane Brunner
+SyxbEaEQ2
+Talwrii
+theswitch
+tomasm
+Tom X. Tobin
+tyjak
+Tyjak
+Zack Gold

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ i3pystatus
 .. image:: https://travis-ci.org/enkore/i3pystatus.svg?branch=master
     :target: https://travis-ci.org/enkore/i3pystatus
 
-i3pystatus is a growing collection of python scripts for 
+i3pystatus is a growing collection of python scripts for
 status output compatible to i3status / i3bar of the i3 window manager.
 
 Installation
@@ -47,63 +47,9 @@ Changelog
 Contributors
 ------------
 
-*  aaron-lebo
-*  Alastair Houghton
-*  Alexis Lahouze
-*  Alex Timmermann
-*  Andrés Martano
-*  Argish42
-*  Armin Fisslthaler
-*  Arvedui
-*  Baptiste Grenier
-*  bparmentier
-*  Cezary Biele
-*  cganas
-*  Christopher Ganas
-*  Chris Wood
-*  David Foucher
-*  David Garcia Quintas
-*  dubwoc
-*  eBrnd
-*  enkore (current maintainer)
-*  facetoe
-*  Frank Tackitt
-*  gacekjk
-*  Goran Mekić
-*  Gordon Schulz
-*  Hugo Osvaldo Barrera
-*  Iliyas Jorio
-*  Jan Oliver Oelerich (former maintainer)
-*  Jason Hite
-*  Joaquin Ignacio Barotto
-*  Jörg Thalheim
-*  Josef Gajdusek
-*  Júlio Rieger Lucchese
-*  Kenneth Lyons
-*  krypt-n
-*  Lukáš Mandák
-*  Łukasz Jędrzejewski
-*  Matthias Pronk
-*  Matthieu Coudron
-*  Matus Telgarsky
-*  Michael Schmidt
-*  Mikael Knutsson
-*  Naglis Jonaitis
-*  Pandada8
-*  philipdexter
-*  Philip Dexter
-*  Sergei Turukin
-*  siikamiika
-*  Simon
-*  Simon Legner
-*  Stéphane Brunner
-*  Talwrii
-*  theswitch
-*  tomasm
-*  Tom X. Tobin
-*  tyjak
-*  Tyjak
-*  Zack Gold
+A list of all contributors can be found in `CONTRIBUTORS <http://github.com/enkore/i3pystatus/CONTRIBUTORS>`_.
+Particular noteworthy contributors are former maintainer Jan Oliver Oelerich and
+current maintainer enkore.
 
 Contribute
 ----------


### PR DESCRIPTION
CONTRIBUTORS was created with `git log --format=%aN" |sort -u > CONTRIBUTORS`.

This makes the README more manageable and more on point, it also provides a
complete list of all contributors.

A list of contributors is in all likelyhood of secondary interst at best when
evaluating software.