### PR TITLE
Fix blocking clickevents

### DIFF
--- a/docs/i3pystatus.core.rst
+++ b/docs/i3pystatus.core.rst
@@ -9,6 +9,21 @@ core Package
     :undoc-members:
     :show-inheritance:
 
+:mod:`color` Module
+-------------------
+
+.. automodule:: i3pystatus.core.color
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`command` Module
+---------------------
+
+.. automodule:: i3pystatus.core.command
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 :mod:`desktop` Module
 ---------------------
@@ -74,11 +89,4 @@ core Package
     :undoc-members:
     :show-inheritance:
 
-:mod:`color` Module
--------------------
-
-.. automodule:: i3pystatus.core.color
-    :members:
-    :undoc-members:
-    :show-inheritance:
 

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -25,13 +25,14 @@ def run_through_shell(command, enable_shell=False):
      string since shell does all the parsing.
     """
 
-    if not enable_shell and not isinstance(command, list):
+    if not enable_shell and isinstance(command, str):
         command = shlex.split(command)
 
     returncode = None
     stderr = None
     try:
-        proc = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=enable_shell)
+        proc = subprocess.Popen(command, stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE, shell=enable_shell)
         out, stderr = proc.communicate()
         out = out.decode("UTF-8")
         stderr = stderr.decode("UTF-8")
@@ -64,10 +65,13 @@ def execute(command, detach=False):
 
     if detach:
         if not isinstance(command, str):
-            raise TypeError("Detached mode expects a string as command.")
+            msg = "Detached mode expects a string as command, not {}".format(
+                  command)
+            logging.getLogger("i3pystatus.core.command").error(msg)
+            raise AttributeError(msg)
         command = ["i3-msg", "exec", command]
     else:
-        if not isinstance(command, list):
+        if isinstance(command, str):
             command = shlex.split(command)
 
     try:

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -40,20 +40,24 @@ def run_through_shell(command, enable_shell=False):
 
 def execute(command, detach=False):
     """
-    Runs a command in background.
-    No output is retrieved.
-    Useful for running GUI applications that would block click events.
+    Runs a command in background. No output is retrieved. Useful for running GUI
+    applications that would block click events.
 
-    :param detach If set to `True` the application will be executed using the
-    `i3-msg` command (survives i3 in-place restart).
+    :param command: A string or a list of strings containing the name and
+     arguments of the program.
+    :param detach: If set to `True` the program will be executed using the
+     `i3-msg` command. As a result the program is executed independent of
+     i3pystatus as a child of i3 process. Because of how i3-msg parses its
+     arguments the type of `command` is limited to string in this mode.
     """
 
-    if not isinstance(command, list):
-        command = command.split()
-
     if detach:
-        command.insert(0, "exec")
-        command.insert(0, "i3-msg")
+        if not isinstance(command, str):
+            raise TypeError("Detached mode expects a string as command.")
+        command = ["i3-msg", "exec", command]
+    else:
+        if not isinstance(command, list):
+            command = command.split()
 
     try:
         subprocess.Popen(command, stdin=subprocess.DEVNULL,

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -7,11 +7,21 @@ CommandResult = namedtuple("Result", ['rc', 'out', 'err'])
 
 def run_through_shell(command, enable_shell=False):
     """
-    Retrieves output of command
-    Returns tuple success (boolean)/ stdout(string) / stderr (string)
+    Retrieve output of a command.
+    Returns a named tuple with three elements:
 
-    Don't use this function with programs that outputs lots of data since the output is saved
-    in one variable
+    * ``rc`` (integer) Return code of command.
+    * ``out`` (string) Everything that was printed to stdout.
+    * ``err`` (string) Everything that was printed to stderr.
+
+    Don't use this function with programs that outputs lots of data since the
+    output is saved in one variable.
+
+    :param command: A string or a list of strings containing the name and
+     arguments of the program.
+    :param enable_shell: If set ot `True` users default shell will be invoked
+     and given ``command`` to execute. The ``command`` should obviously be a
+     string since shell does all the parsing.
     """
 
     if not enable_shell and not isinstance(command, list):

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -30,22 +30,22 @@ def run_through_shell(command, enable_shell=False):
     except OSError as e:
         out = e.strerror
         stderr = e.strerror
-        logging.getLogger("i3pystatus.command").exception("")
+        logging.getLogger("i3pystatus.core.command").exception("")
     except subprocess.CalledProcessError as e:
         out = e.output
-        logging.getLogger("i3pystatus.command").exception("")
+        logging.getLogger("i3pystatus.core.command").exception("")
 
     return CommandResult(returncode, out, stderr)
 
 
-def run_in_background(command, detach=False):
+def execute(command, detach=False):
     """
     Runs a command in background.
     No output is retrieved.
     Useful for running GUI applications that would block click events.
 
     :param detach If set to `True` the application will be executed using the
-    `i3-msg` command.
+    `i3-msg` command (survives i3 in-place restart).
     """
 
     if not isinstance(command, list):
@@ -59,6 +59,6 @@ def run_in_background(command, detach=False):
         subprocess.Popen(command, stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError:
-        logging.getLogger("i3pystatus.command").exception("")
+        logging.getLogger("i3pystatus.core.command").exception("")
     except subprocess.CalledProcessError:
-        logging.getLogger("i3pystatus.command").exception("")
+        logging.getLogger("i3pystatus.core.command").exception("")

--- a/i3pystatus/core/command.py
+++ b/i3pystatus/core/command.py
@@ -1,6 +1,7 @@
 import logging
-from collections import namedtuple
+import shlex
 import subprocess
+from collections import namedtuple
 
 CommandResult = namedtuple("Result", ['rc', 'out', 'err'])
 
@@ -25,7 +26,7 @@ def run_through_shell(command, enable_shell=False):
     """
 
     if not enable_shell and not isinstance(command, list):
-        command = command.split()
+        command = shlex.split(command)
 
     returncode = None
     stderr = None
@@ -67,7 +68,7 @@ def execute(command, detach=False):
         command = ["i3-msg", "exec", command]
     else:
         if not isinstance(command, list):
-            command = command.split()
+            command = shlex.split(command)
 
     try:
         subprocess.Popen(command, stdin=subprocess.DEVNULL,

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -48,31 +48,39 @@ class Module(SettingsBase):
 
     def on_click(self, button):
         """
-        Maps a click event (include mousewheel events) with its associated callback.
-        It then triggers the callback depending on the nature (ie type) of
-        the callback variable:
-        1. if null callback, do nothing
-        2. if it's a python function ()
-        3. if it's the name of a method of the current module (string)
+        Maps a click event with its associated callback.
 
-        To setup the callbacks, you can set the settings 'on_leftclick',
-        'on_rightclick', 'on_upscroll', 'on_downscroll'.
+        Currently implemented events are:
 
-        For instance, you can test with:
-        ::
+        ===========  ================  =========
+        Event        Callback setting  Button ID
+        ===========  ================  =========
+        Left click   on_leftclick      1
+        Right click  on_rightclick     3
+        Scroll up    on_upscroll       4
+        Scroll down  on_downscroll     5
+        ===========  ================  =========
 
-            status.register("clock",
-                    format=[
-                        ("Format 0",'Europe/London'),
-                        ("%a %-d Format 1",'Europe/Dublin'),
-                        "%a %-d %b %X format 2",
-                        ("%a %-d %b %X format 3", 'Europe/Paris'),
-                    ],
-                    on_leftclick= ["urxvtc"] , # launch urxvtc on left click
-                    on_rightclick= ["scroll_format", 2] , # update format by steps of 2
-                    on_upscroll= [print, "hello world"] , # call python function print
-                    log_level=logging.DEBUG,
-                    )
+        The action is determined by the nature (type and value) of the callback
+        setting in the following order:
+
+        1. If null callback (``None``), no action is taken.
+        2. If it's a `python function`, call it and pass any additional
+           arguments.
+        3. If it's name of a `member method` of current module (string), call it
+           and pass any additional arguments.
+        4. If the name does not match with `member method` name execute program
+           with such name.
+
+        .. seealso:: :ref:`callbacks` for more information about
+         callback settings and examples.
+
+        :param button: The ID of button event received from i3bar.
+        :type button: int
+        :return: Returns ``True`` if a valid callback action was executed.
+         ``False`` otherwise.
+        :rtype: bool
+
         """
 
         def log_event(name, button, cb, args, action):

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -102,7 +102,7 @@ class Module(SettingsBase):
             self.logger.debug("cb=%s args=%s" % (cb, args))
 
         if callable(cb):
-            cb(self)
+            cb(self, *args)
         elif hasattr(self, cb):
             if cb is not "run":
                 getattr(self, cb)(*args)

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -75,6 +75,11 @@ class Module(SettingsBase):
                     )
         """
 
+        def log_event(name, button, cb, args, action):
+            msg = "{}: button={}, cb='{}', args={}, type='{}'".format(
+                  name, button, cb, args, action)
+            self.logger.debug(msg)
+
         def split_callback_and_args(cb):
             if isinstance(cb, list):
                 return cb[0], cb[1:]
@@ -91,23 +96,25 @@ class Module(SettingsBase):
         elif button == 5:  # mouse wheel down
             cb = self.on_downscroll
         else:
-            self.logger.info("Button '%d' not handled yet." % (button))
+            log_event(self.__name__, button, None, None, "Unhandled button")
             return False
 
         if not cb:
-            self.logger.info("no cb attached")
+            log_event(self.__name__, button, None, None, "No callback attached")
             return False
         else:
             cb, args = split_callback_and_args(cb)
-            self.logger.debug("cb=%s args=%s" % (cb, args))
 
         if callable(cb):
             cb(self, *args)
+            log_event(self.__name__, button, cb, args, "Python callback")
         elif hasattr(self, cb):
             if cb is not "run":
                 getattr(self, cb)(*args)
+                log_event(self.__name__, button, cb, args, "Member callback")
         else:
             execute(cb, detach=True)
+            log_event(self.__name__, button, cb, args, "External command")
         return True
 
     def move(self, position):

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -1,6 +1,7 @@
 from i3pystatus.core.settings import SettingsBase
 from i3pystatus.core.threading import Manager
 from i3pystatus.core.util import convert_position
+from i3pystatus.core.command import execute
 from i3pystatus.core.command import run_through_shell
 
 
@@ -106,7 +107,7 @@ class Module(SettingsBase):
             if cb is not "run":
                 getattr(self, cb)(*args)
         else:
-            run_through_shell(cb, *args)
+            execute(cb, *args)
         return True
 
     def move(self, position):

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -106,15 +106,15 @@ class Module(SettingsBase):
             cb, args = split_callback_and_args(cb)
 
         if callable(cb):
-            cb(self, *args)
             log_event(self.__name__, button, cb, args, "Python callback")
+            cb(self, *args)
         elif hasattr(self, cb):
             if cb is not "run":
-                getattr(self, cb)(*args)
                 log_event(self.__name__, button, cb, args, "Member callback")
+                getattr(self, cb)(*args)
         else:
-            execute(cb, detach=True)
             log_event(self.__name__, button, cb, args, "External command")
+            execute(cb, detach=True)
         return True
 
     def move(self, position):

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -107,7 +107,7 @@ class Module(SettingsBase):
             if cb is not "run":
                 getattr(self, cb)(*args)
         else:
-            execute(cb, *args)
+            execute(cb, detach=True)
         return True
 
     def move(self, position):

--- a/i3pystatus/core/settings.py
+++ b/i3pystatus/core/settings.py
@@ -99,7 +99,10 @@ class SettingsBase(metaclass=SettingsBaseMeta):
             raise ConfigMissingError(
                 type(self).__name__, missing=exc.keys) from exc
 
-        self.logger = logging.getLogger(self.__name__)
+        if self.__name__.startswith("i3pystatus"):
+            self.logger = logging.getLogger(self.__name__)
+        else:
+            self.logger = logging.getLogger("i3pystatus." + self.__name__)
         self.logger.setLevel(self.log_level)
         self.init()
 


### PR DESCRIPTION
Added new function `execute` to run external programs without waiting for their output (#254).

Also some additions to `run_through_shell`:
* Arguments are separated automatically if shell is not enabled. This way you can simply pass the string with the command without using `command.split()` every time you want to run something without using shell.
* Exceptions are now logged. Just in case they ever actually happen.