### PR TITLE
Yaourt backend for updates script

### DIFF
--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -1,18 +1,25 @@
 """
 This module counts the available updates using yaourt.
-You should not use it together with the pacman backend otherwise
-some packeges might be counted twice.
+By default it will only count aur packages.
+If you want to count both pacman and aur packages set the variable
+count_only_aur = False
 """
-
+import re
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.updates import Backend
 
 
 class Yaourt(Backend):
-
+    def __init__(self, aur_only = True):
+        self.aur_only = aur_only
+    
     @property
+    
     def updates(self):
         command = ["yaourt", "-Qua"]
         checkupdates = run_through_shell(command)
-        return checkupdates.out.count('\n')
+        if(self.aur_only):
+            return len( re.findall("^aur/",  checkupdates.out, flags=re.M) )
+        return checkupdates.out.count("\n")
+
 Backend = Yaourt

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -9,15 +9,13 @@ class Yaourt(Backend):
     By default it will only count aur packages. Thus it can be used with the pacman backend like this:
 
     from i3pystatus.updates import pacman, yaourt
-    status.register("updates",
-        backends = [pacman.Pacman(), yaourt.Yaourt()])
+    status.register("updates", backends = [pacman.Pacman(), yaourt.Yaourt()])
 
     If you want to count both pacman and aur packages with this module you can set the variable
     count_only_aur = False like this:
 
     from i3pystatus.updates import yaourt
-    status.register("updates",
-        backends = [yaourt.Yaourt(False)])
+    status.register("updates", backends = [yaourt.Yaourt(False)])
     """
 
     def __init__(self, aur_only=True):

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -1,15 +1,25 @@
-"""
-This module counts the available updates using yaourt.
-By default it will only count aur packages.
-If you want to count both pacman and aur packages set the variable
-count_only_aur = False
-"""
 import re
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.updates import Backend
 
 
 class Yaourt(Backend):
+    """
+    This module counts the available updates using yaourt.
+    By default it will only count aur packages. Thus it can be used with the pacman backend like this:
+
+    from i3pystatus.updates import pacman, yaourt
+    status.register("updates",
+        backends = [pacman.Pacman(), yaourt.Yaourt()])
+
+    If you want to count both pacman and aur packages with this module you can set the variable
+    count_only_aur = False like this:
+
+    from i3pystatus.updates import yaourt
+    status.register("updates",
+        backends = [yaourt.Yaourt(False)])
+    """
+
     def __init__(self, aur_only=True):
         self.aur_only = aur_only
 

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -7,6 +7,7 @@ some packeges might be counted twice.
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.updates import Backend
 
+
 class Yaourt(Backend):
 
     @property

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -1,0 +1,17 @@
+"""
+This module counts the available updates using yaourt.
+You should not use it together with the pacman backend otherwise
+some packeges might be counted twice.
+"""
+
+from i3pystatus.core.command import run_through_shell
+from i3pystatus.updates import Backend
+
+class Yaourt(Backend):
+
+    @property
+    def updates(self):
+        command = ["yaourt", "-Qua"]
+        checkupdates = run_through_shell(command)
+        return checkupdates.out.count('\n')
+Backend = Yaourt

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -10,16 +10,15 @@ from i3pystatus.updates import Backend
 
 
 class Yaourt(Backend):
-    def __init__(self, aur_only = True):
+    def __init__(self, aur_only=True):
         self.aur_only = aur_only
-    
+
     @property
-    
     def updates(self):
         command = ["yaourt", "-Qua"]
         checkupdates = run_through_shell(command)
         if(self.aur_only):
-            return len( re.findall("^aur/",  checkupdates.out, flags=re.M) )
+            return len(re.findall("^aur/", checkupdates.out, flags=re.M))
         return checkupdates.out.count("\n")
 
 Backend = Yaourt


### PR DESCRIPTION
I wrote a backend for the updates module to support the AUR helper Yaourt.
The backend supports 2 modes: 
In the aur_only mode it will count only those packages with new updates available from the AUR. So it can be used in conjunction with the pacman backend to get the total update count like this:

    from i3pystatus.updates import pacman, yaourt
    status.register("updates",
        backends = [pacman.Pacman(), yaourt.Yaourt(True)])
This mode can also be disabled to get the total update count directly without using the pacman backend:

    from i3pystatus.updates import yaourt
    status.register("updates",
        backends = [yaourt.Yaourt(False)])
