### PR TITLE
shell: added possibility to set markup language used to parse messages

### DIFF
--- a/i3pystatus/shell.py
+++ b/i3pystatus/shell.py
@@ -14,11 +14,13 @@ class Shell(IntervalModule):
 
     color = "#FFFFFF"
     error_color = "#FF0000"
+    markup = "none"
 
     settings = (
         ("command", "command to be executed"),
         ("color", "standard color"),
         ("error_color", "color to use when non zero exit code is returned"),
+        ("markup", "markup language used to parse returned text, e.g. pango"),
         "format"
     )
 
@@ -38,5 +40,6 @@ class Shell(IntervalModule):
 
         self.output = {
             "full_text": self.format.format(output=out) if out else "Command `%s` returned %d" % (self.command, retvalue),
-            "color": self.color if retvalue == 0 else self.error_color
+            "color": self.color if retvalue == 0 else self.error_color,
+            "markup": self.markup if out else "none"
         }


### PR DESCRIPTION
This commit ads possibility to use pango markup langage to parse messages returned by shell commands, for example:
config:
```
status.register("shell",
    command="<path_to_script>",
    markup="pango",)
```

with this script:
```
#!/bin/bash

echo '<span foreground="red">red text</span> <span foreground="green">green text</span>'
```

would produce something like this:
![pango_example](https://cloud.githubusercontent.com/assets/1920906/10381364/6bc8dd06-6e1a-11e5-8a5b-18624956a3f8.png)
