### PR TITLE
 Improved handling of (un)mounted drives/partitions.

### DIFF
--- a/i3pystatus/disk.py
+++ b/i3pystatus/disk.py
@@ -31,10 +31,14 @@ class Disk(IntervalModule):
     round_size = 2
 
     def run(self):
-        stat = os.statvfs(self.path)
-        available = (stat.f_bsize * stat.f_bavail) / self.divisor
+        try:
+            stat = os.statvfs(self.path)
+            available = (stat.f_bsize * stat.f_bavail) / self.divisor
 
-        if available > self.display_limit:
+            if available > self.display_limit:
+                self.output = {}
+                return
+        except:
             self.output = {}
             return
 


### PR DESCRIPTION
If a disk or partition is not mounted the current behaviour is to spit an ill-formatted error. This try/except addition silences these and as such will only display information on mounted disks.