### PR TITLE
 Improved handling of (un)mounted drives/partitions -- take 2.

### DIFF
--- a/i3pystatus/disk.py
+++ b/i3pystatus/disk.py
@@ -37,17 +37,25 @@ class Disk(IntervalModule):
     round_size = 2
     mounted_only = False
 
+    def not_mounted(self):
+        if self.mounted_only:
+            self.output = {}
+        else:
+            self.output = {} if not self.format_not_mounted else {
+                "full_text": self.format_not_mounted,
+                "color": self.color_not_mounted,
+            }
+
     def run(self):
+        if os.path.isdir(self.path) and not os.path.ismount(self.path):
+            if len(os.listdir(self.path)) == 0:
+                self.not_mounted()
+                return
+
         try:
             stat = os.statvfs(self.path)
         except Exception:
-            if self.mounted_only:
-                self.output = {}
-            else:
-                self.output = {} if not self.format_not_mounted else {
-                    "full_text": self.format_not_mounted,
-                    "color": self.color_not_mounted,
-                }
+            self.not_mounted()
             return
 
         available = (stat.f_bsize * stat.f_bavail) / self.divisor

--- a/i3pystatus/disk.py
+++ b/i3pystatus/disk.py
@@ -13,25 +13,43 @@ class Disk(IntervalModule):
     """
 
     settings = (
-        "format", "path",
+        "format",
+        "path",
         ("divisor", "divide all byte values by this value, default is 1024**3 (gigabyte)"),
         ("display_limit", "if more space is available than this limit the module is hidden"),
         ("critical_limit", "critical space limit (see critical_color)"),
         ("critical_color", "the critical color"),
         ("color", "the common color"),
         ("round_size", "precision, None for INT"),
+        ("mounted_only", "display only if path is a valid mountpoint"),
+        "format_not_mounted",
+        "color_not_mounted"
     )
     required = ("path",)
     color = "#FFFFFF"
+    color_not_mounted = "#FFFFFF"
     critical_color = "#FF0000"
     format = "{free}/{avail}"
+    format_not_mounted = None
     divisor = 1024 ** 3
     display_limit = float('Inf')
     critical_limit = 0
     round_size = 2
+    mounted_only = False
 
     def run(self):
-        stat = os.statvfs(self.path)
+        try:
+            stat = os.statvfs(self.path)
+        except Exception:
+            if self.mounted_only:
+                self.output = {}
+            else:
+                self.output = {} if not self.format_not_mounted else {
+                    "full_text": self.format_not_mounted,
+                    "color": self.color_not_mounted,
+                }
+            return
+
         available = (stat.f_bsize * stat.f_bavail) / self.divisor
 
         if available > self.display_limit:


### PR DESCRIPTION
Previously the free space of the underlying filesystem would be reported if the path provided was a directory but not a valid mountpoint. This adds a check to first confirm whether a directory is a mountpoint using os.path.ismount(), and if not, then runs an os.listdir() to count the files; empty directories are considered not mounted.

This functionality allows for usage on setups with NFS and will not report free space of underlying filesystem in cases with local mountpoints as path.


(Original pull request went awry -- https://github.com/enkore/i3pystatus/pull/277)