### PR TITLE
disk module: corrected doc string

### DIFF
--- a/i3pystatus/disk.py
+++ b/i3pystatus/disk.py
@@ -6,7 +6,7 @@ from .core.util import round_dict
 
 class Disk(IntervalModule):
     """
-    Gets ``{used}``, ``{free}``, ``{available}`` and ``{total}`` amount of bytes on the given mounted filesystem.
+    Gets ``{used}``, ``{free}``, ``{avail}`` and ``{total}`` amount of bytes on the given mounted filesystem.
 
     These values can also be expressed as percentages with the ``{percentage_used}``, ``{percentage_free}``
     and ``{percentage_avail}`` formats.


### PR DESCRIPTION
The documentation described the parameters wrong. Fixed in commit