### PR TITLE
Support variants for xkb layouts in xkblayout module

### DIFF
--- a/i3pystatus/xkblayout.py
+++ b/i3pystatus/xkblayout.py
@@ -9,6 +9,8 @@ class Xkblayout(IntervalModule):
     ``layouts`` setting and enables the layout following it. If the
     current layout is not in the ``layouts`` setting the first layout
     is enabled.
+
+    ``layouts`` can be stated with or without variants, e.g.: status.register("xkblayout", layouts=["de neo", "de"])
     """
 
     interval = 1

--- a/i3pystatus/xkblayout.py
+++ b/i3pystatus/xkblayout.py
@@ -20,7 +20,7 @@ class Xkblayout(IntervalModule):
     on_leftclick = "change_layout"
 
     def run(self):
-        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/{print $2}'", shell=True).decode('utf-8').strip()
+        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n"," ").strip()
 
         self.output = {
             "full_text": self.format.format(name=kblayout).upper(),
@@ -29,12 +29,12 @@ class Xkblayout(IntervalModule):
 
     def change_layout(self):
         layouts = self.layouts
-        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/{print $2}'", shell=True).decode('utf-8').strip()
+        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n"," ").strip()
         if kblayout in layouts:
             position = layouts.index(kblayout)
             try:
-                subprocess.check_call(["setxkbmap", layouts[position + 1]])
+                subprocess.check_call(["setxkbmap"] + layouts[position + 1].split())
             except IndexError:
-                subprocess.check_call(["setxkbmap", layouts[0]])
+                subprocess.check_call(["setxkbmap"] + layouts[0].split())
         else:
-            subprocess.check_call(["setxkbmap", layouts[0]])
+            subprocess.check_call(["setxkbmap"] + layouts[0].split())

--- a/i3pystatus/xkblayout.py
+++ b/i3pystatus/xkblayout.py
@@ -20,7 +20,7 @@ class Xkblayout(IntervalModule):
     on_leftclick = "change_layout"
 
     def run(self):
-        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n"," ").strip()
+        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n", " ").strip()
 
         self.output = {
             "full_text": self.format.format(name=kblayout).upper(),
@@ -29,7 +29,7 @@ class Xkblayout(IntervalModule):
 
     def change_layout(self):
         layouts = self.layouts
-        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n"," ").strip()
+        kblayout = subprocess.check_output("setxkbmap -query | awk '/layout/,/variant/{print $2}'", shell=True).decode('utf-8').replace("\n", " ").strip()
         if kblayout in layouts:
             position = layouts.index(kblayout)
             try:


### PR DESCRIPTION
This changes the xkblayout module to support switching between keyboard layouts with variants.

The `layouts` setting can now contain layouts with or without a variant, e.g. ["de", "de neo"].