### PR TITLE
Fix typo in MoonPhase.status.

### DIFF
--- a/i3pystatus/moon.py
+++ b/i3pystatus/moon.py
@@ -46,7 +46,7 @@ class MoonPhase(IntervalModule):
         "Full Moon": "FM",
         "Waning Gibbous": "WanGib",
         "Last Quarter": "LQ",
-        "Waning Cresent": "WanCres",
+        "Waning Crescent": "WanCres",
     }
 
     color = {


### PR DESCRIPTION
This fixes the default shown in the docs, so copy/pasting it into your config won't end up giving you a broken `Waning Crescent` mapping.