### PR TITLE
backlight module increasing brightness on scroll not working

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,7 @@ master branch
 * :py:mod:`.battery`: Added ``bar_design`` formatter
 * :py:mod:`.alsa`: Implemented optional volume display/setting as in AlsaMixer
 * :py:mod:`.pulseaudio`: Fixed bug that created zombies on a click event
+* :py:mod:`.backlight`: Fixed bug preventing brightness increase
   
 3.33 (2015-06-23)
 +++++++++++++++++


### PR DESCRIPTION
The proposed patch calculates the minimal percentage required to change to the next step of brightness instead of using a hardcoded value, which not always work.

**Problem description:**
The module uses xbacklight to change brightness settings, which expects a percentage to be passed as parameter. This number is hardcoded in the module as +5 and -5.

Some displays (or drivers) can't change linearly the brightness settings and have only a discrete amount of steps, which can be read on max_brightness file. 

For xbacklight to work, the percentage passed as parameter should be big enough to increase at least to the next discrete state, otherwise it doesn't work.

For example: If a display allows 15 brightness steps trying to increase +5% doesn't have any effect. It should be >= 6.67 (100/15). Using +7 works for that system.

NOTE: This behaviour is found only increasing the brightness. For decreasing xbacklight will not honour the parameter passed and automatically decrease the required amount.