### PR TITLE
Fix for callbacks.

### DIFF
--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -8,14 +8,6 @@ from i3pystatus.core.command import execute
 from i3pystatus.core.command import run_through_shell
 
 
-def is_method_of(method, object):
-    """Decide whether ``method`` is contained within the MRO of ``object``."""
-    for cls in inspect.getmro(object.__class__):
-        if method in cls.__dict__.values():
-            return True
-    return False
-
-
 class Module(SettingsBase):
     output = None
     position = 0
@@ -90,12 +82,9 @@ class Module(SettingsBase):
         else:
             args = []
 
-        our_method = is_method_of(cb, self)
-        if callable(cb) and not our_method:
+        if callable(cb):
             self.__log_button_event(button, cb, args, "Python callback")
             cb(*args)
-        elif our_method:
-            cb(self, *args)
         elif hasattr(self, cb):
             if cb is not "run":
                 self.__log_button_event(button, cb, args, "Member callback")

--- a/tests/test_module_clicks.py
+++ b/tests/test_module_clicks.py
@@ -67,17 +67,17 @@ def test_clicks(events, expected):
         def set_action(self, action):
             self._action = action
 
-        on_leftclick = [set_action, "leftclick"]
-        on_doubleleftclick = [set_action, "doubleleftclick"]
+        on_leftclick = ["set_action", "leftclick"]
+        on_doubleleftclick = ["set_action", "doubleleftclick"]
 
-        # on_rightclick = [set_action, "rightclick"]
-        on_doublerightclick = [set_action, "doublerightclick"]
+        # on_rightclick = ["set_action", "rightclick"]
+        on_doublerightclick = ["set_action", "doublerightclick"]
 
-        on_upscroll = [set_action, "upscroll"]
-        on_doubleupscroll = [set_action, "doubleupscroll"]
+        on_upscroll = ["set_action", "upscroll"]
+        on_doubleupscroll = ["set_action", "doubleupscroll"]
 
-        on_downscroll = [set_action, "downscroll"]
-        # on_doubledownscroll = [set_action, "doubledownscroll"]
+        on_downscroll = ["set_action", "downscroll"]
+        # on_doubledownscroll = ["set_action", "doubledownscroll"]
 
         _action = 'no action'
 


### PR DESCRIPTION
Removed code did what `hasattr` is already doing one line below.
Also caused exception when member callback was called: trying to call `cb`
which is a `str` as function.

The only change needed for #304 was to remove `self` argument when calling python callback.

Edit: ~~Or maybe not?~~