### PR TITLE
nvidia_temp: add module to display GPU temp

### DIFF
--- a/i3pystatus/nvidia_temp.py
+++ b/i3pystatus/nvidia_temp.py
@@ -24,11 +24,10 @@ class NvidiaTemperature(IntervalModule):
 
     def run(self):
         # call nvidia-smi and strip newlines
-        ret = subprocess.run(
+        ret = subprocess.getoutput(
             ['nvidia-smi',
              '--query-gpu=temperature.gpu',
-             '--format=csv,noheader'],
-            stdout=subprocess.PIPE).stdout.strip()
+             '--format=csv,noheader']).strip()
         # convirt string to int
         temp = int(ret)
 

--- a/i3pystatus/nvidia_temp.py
+++ b/i3pystatus/nvidia_temp.py
@@ -1,0 +1,38 @@
+import subprocess
+from i3pystatus import IntervalModule
+
+
+class NvidiaTemperature(IntervalModule):
+    """
+    Shows nVidia GPU temperature
+    """
+
+    settings = (
+        ("format",
+         "format string used for output. {temp} is the temperature in ",
+         "degrees celsius"),
+        "color",
+        "alert_temp",
+        "alert_color",
+        "interval"
+    )
+    format = "{temp} °C"
+    color = "#FFFFFF"
+    alert_temp = 90
+    alert_color = "#FF0000"
+    interval = 5
+
+    def run(self):
+        # call nvidia-smi and strip newlines
+        ret = subprocess.run(
+            ['nvidia-smi',
+             '--query-gpu=temperature.gpu',
+             '--format=csv,noheader'],
+            stdout=subprocess.PIPE).stdout.strip()
+        # convirt string to int
+        temp = int(ret)
+
+        self.output = {
+            "full_text": self.format.format(temp=temp),
+            "color": self.color if temp < self.alert_temp else self.alert_color
+        }

--- a/tests/test_nvidia_temp.py
+++ b/tests/test_nvidia_temp.py
@@ -1,0 +1,26 @@
+"""
+Basic test for the nvidia_temp module
+"""
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock
+from i3pystatus import nvidia_temp
+
+
+class TestNvidiaTemperature(unittest.TestCase):
+
+    def test_nvidia_temp(self):
+        """
+        Test the return of nvidia_temp module
+        """
+        cases = ('57', '41', '47')
+        for temperature in cases:
+            subprocess.getoutput = MagicMock(return_value=temperature)
+            nvt = nvidia_temp.NvidiaTemperature()
+            nvt.run()
+            self.assertTrue(nvt.output['full_text'] == '%s °C' % temperature)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch includes a module that displays the GPU tempurate for an
NVidia video card.  The module relies on a system utility called
'nvidia-smi', which is usually installed on the system when the video
card driver is installed.