### PR TITLE
weather.py: Add settings entry for color_icons

### DIFF
--- a/i3pystatus/weather.py
+++ b/i3pystatus/weather.py
@@ -28,6 +28,9 @@ class Weather(IntervalModule):
     settings = (
         ("location_code", "Location code from www.weather.com"),
         ("colorize", "Enable color with temperature and UTF-8 icons."),
+        ("color_icons", "Dictionary mapping weather conditions to tuples "
+                        "containing a UTF-8 code for the icon, and the color "
+                        "to be used."),
         ("units", "Celsius (metric) or Fahrenheit (imperial)"),
         "format",
     )


### PR DESCRIPTION
This allows this item to be overridden in i3pystatus with custom colors
and icons.