### PR TITLE
Fix KeyError when using backend-specific updates formatter

### DIFF
--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -92,6 +92,11 @@ class Updates(Module):
 
     @require(internet)
     def check_updates(self):
+        for backend in self.backends:
+            key = backend.__class__.__name__
+            if key not in self.data:
+                self.data[key] = '?'
+
         self.output = {
             "full_text": formatp(self.format_working, **self.data).strip(),
             "color": self.color_working,


### PR DESCRIPTION
When a backend-specific formatter (i.e. ``{Pacman}``, ``{Cower}``, etc.)
is used, and the initial "working" status is set, the loop in which the
update totals is compiled has not yet run, leading to a KeyError.

This commit fixes the traceback by setting initial values of "?" for
these formatters before the initial "working" status is set.