### PR TITLE
core: Change command_endpoint and on_click for supporting i3bar mouse positions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,7 @@ Kenneth Lyons
 krypt-n
 Lukáš Mandák
 Łukasz Jędrzejewski
+Mathis Felardos
 Matthias Pronk
 Matthieu Coudron
 Matus Telgarsky

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -29,9 +29,16 @@ class CommandEndpoint:
         self.thread.start()
 
     def _command_endpoint(self):
-        for command in self.io_handler_factory().read():
-            target_module = self.modules.get(command["instance"])
-            if target_module and target_module.on_click(command["button"]):
+        for cmd in self.io_handler_factory().read():
+            target_module = self.modules.get(cmd["instance"])
+
+            try:
+                pos = {"pos_x": int(cmd["x"]),
+                       "pos_y": int(cmd["y"])}
+            except Exception:
+                pos = {}
+
+            if target_module and target_module.on_click(cmd["button"], **pos):
                 target_module.run()
                 self.io.async_refresh()
 

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -32,14 +32,16 @@ class CommandEndpoint:
         for cmd in self.io_handler_factory().read():
             target_module = self.modules.get(cmd["instance"])
 
+            button = cmd["button"]
+            kwargs = {"button_id": button}
             try:
-                pos = {"pos_x": int(cmd["x"]),
-                       "pos_y": int(cmd["y"])}
+                kwargs.update({"pos_x": cmd["x"],
+                               "pos_y": cmd["y"]})
             except Exception:
-                pos = {}
+                continue
 
             if target_module:
-                target_module.on_click(cmd["button"], **pos)
+                target_module.on_click(button, **kwargs)
                 target_module.run()
                 self.io.async_refresh()
 

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -38,7 +38,8 @@ class CommandEndpoint:
             except Exception:
                 pos = {}
 
-            if target_module and target_module.on_click(cmd["button"], **pos):
+            if target_module:
+                target_module.on_click(cmd["button"], **pos)
                 target_module.run()
                 self.io.async_refresh()
 

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -26,25 +26,35 @@ class Module(SettingsBase):
 
     settings = (
         ('on_leftclick', "Callback called on left click (see :ref:`callbacks`)"),
+        ('on_middleclick', "Callback called on middle click (see :ref:`callbacks`)"),
         ('on_rightclick', "Callback called on right click (see :ref:`callbacks`)"),
         ('on_upscroll', "Callback called on scrolling up (see :ref:`callbacks`)"),
         ('on_downscroll', "Callback called on scrolling down (see :ref:`callbacks`)"),
         ('on_doubleleftclick', "Callback called on double left click (see :ref:`callbacks`)"),
+        ('on_doubleleftclick', "Callback called on double left click (see :ref:`callbacks`)"),
+        ('on_doublemiddleclick', "Callback called on double middle click (see :ref:`callbacks`)"),
         ('on_doublerightclick', "Callback called on double right click (see :ref:`callbacks`)"),
         ('on_doubleupscroll', "Callback called on double scroll up (see :ref:`callbacks`)"),
         ('on_doubledownscroll', "Callback called on double scroll down (see :ref:`callbacks`)"),
+        ('on_unhandledclick', "Callback called on unhandled click (see :ref:`callbacks`)"),
+        ('on_doubleunhandledclick', "Callback called on double unhandled click (see :ref:`callbacks`)"),
         ('multi_click_timeout', "Time (in seconds) before a single click is executed."),
         ('hints', "Additional output blocks for module output (see :ref:`hints`)"),
     )
 
     on_leftclick = None
+    on_middleclick = None
     on_rightclick = None
     on_upscroll = None
     on_downscroll = None
     on_doubleleftclick = None
+    on_doublemiddleclick = None
     on_doublerightclick = None
     on_doubleupscroll = None
     on_doubledownscroll = None
+
+    on_unhandledclick = None
+    on_doubleunhandledclick = None
 
     multi_click_timeout = 0.25
 
@@ -189,21 +199,15 @@ class Module(SettingsBase):
          positions of the mouse where the click occured.
         :return: Returns ``True`` if a valid callback action was executed.
          ``False`` otherwise.
-        :rtype: bool
-
         """
 
-        if button == 1:  # Left mouse button
-            action = 'leftclick'
-        elif button == 3:  # Right mouse button
-            action = 'rightclick'
-        elif button == 4:  # mouse wheel up
-            action = 'upscroll'
-        elif button == 5:  # mouse wheel down
-            action = 'downscroll'
-        else:
+        actions = ['leftclick', 'middleclick', 'rightclick',
+                   'upscroll', 'downscroll']
+        try:
+            action = actions[button - 1]
+        except (TypeError, IndexError):
             self.__log_button_event(button, None, None, "Unhandled button")
-            return False
+            action = "unhandled"
 
         m_click = self.__multi_click
 
@@ -224,8 +228,6 @@ class Module(SettingsBase):
                 m_click.set_timer(button, cb, **kwargs)
             else:
                 self.__button_callback_handler(button, cb, **kwargs)
-
-        return True
 
     def move(self, position):
         self.position = position

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -90,9 +90,14 @@ class Module(SettingsBase):
             wrapped_cb = getattr(cb, "__wrapped__", None)
             if wrapped_cb:
                 locals()["self"] = self  # Add self to the local stack frame
-                args_spec = inspect.getargspec(wrapped_cb)
+                tmp_cb = wrapped_cb
             else:
-                args_spec = inspect.getargspec(cb)
+                tmp_cb = cb
+
+            try:
+                args_spec = inspect.getargspec(tmp_cb)
+            except Exception:
+                args_spec = inspect.ArgSpec([], None, None, None)
 
             # Remove all variables present in kwargs that are not used in the
             # callback, except if there is a keyword argument.

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -36,8 +36,8 @@ class Module(SettingsBase):
         ('on_doublerightclick', "Callback called on double right click (see :ref:`callbacks`)"),
         ('on_doubleupscroll', "Callback called on double scroll up (see :ref:`callbacks`)"),
         ('on_doubledownscroll', "Callback called on double scroll down (see :ref:`callbacks`)"),
-        ('on_unhandledclick', "Callback called on unhandled click (see :ref:`callbacks`)"),
-        ('on_doubleunhandledclick', "Callback called on double unhandled click (see :ref:`callbacks`)"),
+        ('on_otherclick', "Callback called on other click (see :ref:`callbacks`)"),
+        ('on_doubleotherclick', "Callback called on double other click (see :ref:`callbacks`)"),
         ('multi_click_timeout', "Time (in seconds) before a single click is executed."),
         ('hints', "Additional output blocks for module output (see :ref:`hints`)"),
     )
@@ -53,8 +53,8 @@ class Module(SettingsBase):
     on_doubleupscroll = None
     on_doubledownscroll = None
 
-    on_unhandledclick = None
-    on_doubleunhandledclick = None
+    on_otherclick = None
+    on_doubleotherclick = None
 
     multi_click_timeout = 0.25
 
@@ -171,14 +171,16 @@ class Module(SettingsBase):
 
         Currently implemented events are:
 
-        ===========  ================  =========
-        Event        Callback setting  Button ID
-        ===========  ================  =========
-        Left click   on_leftclick      1
-        Right click  on_rightclick     3
-        Scroll up    on_upscroll       4
-        Scroll down  on_downscroll     5
-        ===========  ================  =========
+        ============  ================  =========
+        Event         Callback setting  Button ID
+        ============  ================  =========
+        Left click    on_leftclick      1
+        Middle click  on_middleclick    2
+        Right click   on_rightclick     3
+        Scroll up     on_upscroll       4
+        Scroll down   on_downscroll     5
+        Others        on_otherclick     > 5
+        ============  ================  =========
 
         The action is determined by the nature (type and value) of the callback
         setting in the following order:
@@ -206,8 +208,8 @@ class Module(SettingsBase):
         try:
             action = actions[button - 1]
         except (TypeError, IndexError):
-            self.__log_button_event(button, None, None, "Unhandled button")
-            action = "unhandled"
+            self.__log_button_event(button, None, None, "Other button")
+            action = "otherclick"
 
         m_click = self.__multi_click
 

--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -514,8 +514,9 @@ class MultiClickHandler(object):
         self.timer = None
         self.button = None
         self.cb = None
+        self.kwargs = None
 
-    def set_timer(self, button, cb):
+    def set_timer(self, button, cb, **kwargs):
         with self.lock:
             self.clear_timer()
 
@@ -524,6 +525,7 @@ class MultiClickHandler(object):
                                args=[self._timer_id])
             self.button = button
             self.cb = cb
+            self.kwargs = kwargs
 
             self.timer.start()
 
@@ -544,7 +546,7 @@ class MultiClickHandler(object):
         with self.lock:
             if self._timer_id != timer_id:
                 return
-            self.callback_handler(self.button, self.cb)
+            self.callback_handler(self.button, self.cb, **self.kwargs)
             self.clear_timer()
 
     def check_double(self, button):
@@ -553,7 +555,7 @@ class MultiClickHandler(object):
 
         ret = True
         if button != self.button:
-            self.callback_handler(self.button, self.cb)
+            self.callback_handler(self.button, self.cb, **self.kwargs)
             ret = False
 
         self.clear_timer()


### PR DESCRIPTION
Hello,

Here the change of this patch:

* `command_endpoint`: get the position from the mouse when the click
  occured. Parameters names are set here: `pos_x` `pos_y`.
  Positions are passed to on_click through keyword arguments.
* `Module`:
  - change `__log_button_event`, `__button_callback_handler` and `on_click`
    methods for handling keyword arguments.
  - "Member", "Method" and "Python" callbacks are handled by detecting
    if they have `pos_x` or `pos_y` as parameters, or if they have a
    keyword arguments. The special case of wrapped callbacks (made with
    `get_module` decorator for example) is handled in a similar way.
  - "External command" is handled by considering the position as a
    format dictionary. Actually no distinctions are made of how
    `self.data` and the new keyword argument are treated on this.
  - the parameter `kwargs` as been added to the doc string of `on_click`.
* `MultiClickHandler`: now handle keyword arguments.

It's a great feature for adding graphical interface on the top of the status bar.
I think we should add this to the doc if the change is accepted :)

Regards,

-- 
Mathis 'hasB4K' FELARDOS