### PR TITLE
Change color_no_updates to None to default to i3bar color

### DIFF
--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -65,7 +65,7 @@ class Updates(Module):
     format_no_updates = None
     format_working = None
     color = "#00DD00"
-    color_no_updates = "#FFFFFF"
+    color_no_updates = None
     color_working = None
 
     on_leftclick = "run"


### PR DESCRIPTION
If ``statusline`` is not set in ``~/.config/i3/config``, it defaults to
``#ffffff`` (white). Therefore, the default behavior of the updates
module in this case is to show white for both ``color_no_updates``
(system is up-to-date) and ``color_working`` (update check in progress).

However, if one sets ``statusline`` in their ``~/.config/i3/config``,
then the color will be white when the system is up-to-date, forcing the
user to manually set ``color_no_updates`` if they would prefer it match
their default i3bar color.

This commit changes the default value of ``color_no_updates`` to
``None`` so that it matches the default i3bar unless overridden.