### PR TITLE
dpms: Allow a different format string when DPMS is disabled.

### DIFF
--- a/i3pystatus/dpms.py
+++ b/i3pystatus/dpms.py
@@ -17,6 +17,7 @@ class DPMS(IntervalModule):
 
     settings = (
         "format",
+        "format_disabled",
         "color",
         "color_disabled",
     )
@@ -24,6 +25,7 @@ class DPMS(IntervalModule):
     color_disabled = "#AAAAAA"
     color = "#FFFFFF"
     format = "DPMS: {status}"
+    format_disabled = "DPMS: {status}"
 
     on_leftclick = "toggle_dpms"
 
@@ -33,10 +35,16 @@ class DPMS(IntervalModule):
 
         self.status = run_through_shell("xset -q | grep -q 'DPMS is Enabled'", True).rc == 0
 
-        self.output = {
-            "full_text": self.format.format(status='on' if self.status else 'off'),
-            "color": self.color if self.status else self.color_disabled
-        }
+        if self.status:
+            self.output = {
+                "full_text": self.format.format(status="off"),
+                "color": self.color
+            }
+        else:
+            self.output = {
+                "full_text": self.format_disabled.format(status="off"),
+                "color": self.color_disabled
+            }
 
     def toggle_dpms(self):
         if self.status:


### PR DESCRIPTION
Substitution of {status} is still possible, for backwards compatibility.