### PR TITLE
Respect keyring_backend settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,8 +39,8 @@ MOCK_MODULES = [
     "dateutil",
     "httplib2",
     "oauth2client",
-    "apiclient"
-
+    "apiclient",
+    "keyring"
 ]
 
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
Uses the keyring_backend keyring to get the Github password.  For some reason this was not properly used.

Also adds an extra option to redirect the user to their Github profile page (the default option as it was before)  or directly to their notifications page.