### PR TITLE
Fix improper usage of time.tzset()

### DIFF
--- a/i3pystatus/clock.py
+++ b/i3pystatus/clock.py
@@ -88,7 +88,8 @@ class Clock(IntervalModule):
         self._non_daylight_zone = time.tzname[0]
         self.format = self.expand_formats(self.format)
 
-    def _get_local_tz(self):
+    @staticmethod
+    def _get_local_tz():
         '''
         Returns a string representing localtime, suitable for setting localtime
         using time.tzset().

--- a/i3pystatus/clock.py
+++ b/i3pystatus/clock.py
@@ -95,10 +95,7 @@ class Clock(IntervalModule):
 
         https://docs.python.org/3/library/time.html#time.tzset
         '''
-        hours_offset = time.altzone / 3600.0
-        if time.localtime().tm_isdst == 1:
-            # We're currently in DST, add 1 to the offset
-            hours_offset += 1
+        hours_offset = time.timezone / 3600.0
         plus_minus = '+' if hours_offset >= 0 else '-'
         hh = int(hours_offset)
         mm = 60 * (hours_offset % 1)


### PR DESCRIPTION
[time.tzname](https://docs.python.org/3/library/time.html#time.tzname) is a tuple containing the non-daylight-savings and daylight-savings timezone abbreviations. However, when the ``TZ`` environment variable is set to just the daylight-savings timezone (as the clock module was changed to do in e31c58f, specifically [here](https://github.com/enkore/i3pystatus/commit/e31c58f1ade860dc497b424aff7bc971928249a6#diff-36c50376601a5e62fdec33ff32a80481R78)), [time.tzset()](https://docs.python.org/3/library/time.html#time.tzset) will break [time.tzname](https://docs.python.org/3/library/time.html#time.tzname) by setting both elements of the tuple to that timezone, causing the effective timezone to fallback to UTC:

```python
>>> time.tzname
('CST', 'CDT')
>>> time.localtime().tm_hour
1
>>> os.environ.putenv('TZ', 'CST')
>>> time.tzset()
>>> time.tzname
('CST', 'CST')
>>> # ^^^ This is broken
...
>>> time.localtime().tm_hour
6
>>> os.environ.putenv('TZ', 'CST+06:00CDT')
>>> time.tzset()
>>> time.tzname
('CST', 'CDT')
>>> time.localtime().tm_hour
1
```

This fixes this incorrect behavior by building a proper ``TZ`` environment variable to set localtime.