### PR TITLE
Properly set MPD filename if no title

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -114,7 +114,7 @@ class MPD(IntervalModule):
             "bitrate": int(status.get("bitrate", 0)),
         }
 
-        if not fdict["title"] and "filename" in fdict:
+        if not fdict["title"]:
             fdict["filename"] = '.'.join(
                 basename(currentsong["file"]).split('.')[:-1])
         else:


### PR DESCRIPTION
If there is no title for the current song, filename should be set. This PR fixes that behaviour (before, no filename was set due to an incorrect if statement)