### PR TITLE
Introduce latency plugin (IPv4 only at the moment)

### DIFF
--- a/docs/i3pystatus.rst
+++ b/docs/i3pystatus.rst
@@ -10,7 +10,7 @@ Module reference
          `uname`_ - `uptime`_ - `xkblayout`_
 :Audio: `alsa`_ - `pulseaudio`_
 :Hardware: `backlight`_ - `battery`_ - `temp`_
-:Network: `net_speed`_ - `network`_ - `online`_ - `openstack_vms`_ - `openvpn`_
+:Network: `latency`_ - `net_speed`_ - `network`_ - `online`_ - `openstack_vms`_ - `openvpn`_
 :Music: `cmus`_ - `mpd`_ - `now_playing`_ - `pianobar`_ - `spotify`_
 :Websites: `bitcoin`_ - `dota2wins`_ - `github`_ - `modsde`_ - `parcel`_ - `reddit`_ - `weather`_ -
            `whosonlocation`_

--- a/i3pystatus/latency.py
+++ b/i3pystatus/latency.py
@@ -1,0 +1,59 @@
+from i3pystatus import IntervalModule
+import subprocess, re
+
+
+class Latency(IntervalModule):
+
+    """Print internet connection latency."""
+
+    settings = (
+        ('color_good', 'Text color with good latency'),
+        ('color_bad', 'Text color with bad latency'),
+        ('color_offline', 'Text color when offline'),
+        ('latency_threshold', 'Maximum latency to be considered good in ms'),
+        ('format', 'Status text format'),
+        ('format_offline', 'Status text when offline'),
+        ('host', 'Host to ping'),
+    )
+
+    color_good = '#ffffff'
+    color_bad = '#ffff00'
+    color_offline = '#ff0000'
+    latency_threshold = 120
+    format = '{latency} ms'
+    format_offline = 'offline'
+    host = '8.8.8.8'
+    interval = 10
+
+    def run(self):
+        proc = subprocess.run(['ping', '-c1', self.host], stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        if proc.returncode != 0:
+            self.output = {
+                'color': self.color_offline,
+                'full_text': self.format_offline
+            }
+            return
+
+        string = proc.stdout.decode('ascii').split('\n')[-2]
+        match = re.search('[0-9\.]+', string)
+        if match is None:
+            self.output = {
+                'full_text': 'Unknown error'
+            }
+            return
+
+        latency = float(match.group(0))
+        cdict = {
+            'latency': latency
+        }
+
+        if latency > self.latency_threshold:
+            self.output = {
+                'color': self.color_bad,
+                'full_text': self.format.format(**cdict)
+            }
+        else:
+            self.output = {
+                'color': self.color_good,
+                'full_text': self.format.format(**cdict)
+            }


### PR DESCRIPTION
This plugin runs `ping` at regular intervals against a host on the internet to test the current internet connection latency. I built this plugin after using the 'online' plugin, but wanting a way to see the actual connection latency instead of just online/offline status.

The external `ping` utility is necessary since sending ICMP messages requires special capabilities, and it would be impractical to require i3pystatus to be installed with these capabilities which require root privileges to set. Also, there's no Python way to send ICMP messages.