### PR TITLE
Notification with update summary on_rightclick

### DIFF
--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -62,6 +62,9 @@ class Updates(Module):
             "default the same as ``format``."),
         ("format_summary", "Format for the summary line of notifications. By "
             "default the same as ``format``."),
+        ("notification_icon", "Icon shown when reporting the list of updates. "
+            "Default is ``software-update-available``, and can be "
+            "None for no icon."),
         "color",
         "color_no_updates",
         "color_working",
@@ -74,6 +77,7 @@ class Updates(Module):
     format_no_updates = None
     format_working = None
     format_summary = None
+    notification_icon = "software-update-available"
     color = "#00DD00"
     color_no_updates = None
     color_working = None
@@ -147,7 +151,7 @@ class Updates(Module):
         DesktopNotification(
             title=formatp(self.format_summary, **self.data).strip(),
             body="\n".join(self.notif_body.values()),
-            icon="software-update-available",
+            icon=self.notification_icon,
             urgency=1,
             timeout=0,
         ).display()

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -19,6 +19,9 @@ class Updates(Module):
     Left clicking on the module will refresh the count of upgradeable packages.
     This may be used to dismiss the notification after updating your system.
 
+    Right clicking shows a desktop notification with a summary count and a list
+    of available updates.
+
     .. rubric:: Available formatters
 
     * `{count}` — Sum of all available updates from all backends.
@@ -57,6 +60,8 @@ class Updates(Module):
             "are available."),
         ("format_working", "Format used while update queries are run. By "
             "default the same as ``format``."),
+        ("format_summary", "Format for the summary line of notifications. By "
+            "default the same as ``format``."),
         "color",
         "color_no_updates",
         "color_working",
@@ -68,6 +73,7 @@ class Updates(Module):
     format = "Updates: {count}"
     format_no_updates = None
     format_working = None
+    format_summary = None
     color = "#00DD00"
     color_no_updates = None
     color_working = None
@@ -80,6 +86,8 @@ class Updates(Module):
             self.backends = [self.backends]
         if self.format_working is None:  # we want to allow an empty format
             self.format_working = self.format
+        if self.format_summary is None:  # we want to allow an empty format
+            self.format_summary = self.format
         self.color_working = self.color_working or self.color
         self.data = {
             "count": 0
@@ -137,7 +145,7 @@ class Updates(Module):
 
     def report(self):
         DesktopNotification(
-            title=formatp(self.format, **self.data).strip(),
+            title=formatp(self.format_summary, **self.data).strip(),
             body="\n".join(self.notif_body.values()),
             icon="software-update-available",
             urgency=1,

--- a/i3pystatus/updates/__init__.py
+++ b/i3pystatus/updates/__init__.py
@@ -113,9 +113,9 @@ class Updates(Module):
         for backend in self.backends:
             key = backend.__class__.__name__
             if key not in self.data:
-                self.data[key] = '?'
+                self.data[key] = "?"
             if key not in self.notif_body:
-                self.notif_body[key] = '?'
+                self.notif_body[key] = ""
 
         self.output = {
             "full_text": formatp(self.format_working, **self.data).strip(),

--- a/i3pystatus/updates/aptget.py
+++ b/i3pystatus/updates/aptget.py
@@ -23,10 +23,14 @@ class AptGet(Backend):
         command = "apt-get upgrade -s -o Dir::State::Lists=" + cache_dir
         apt = run_through_shell(command.split())
 
-        update_count = 0
-        for line in apt.out.split("\n"):
-            if line.startswith("Inst"):
-                update_count += 1
-        return update_count
+        out = apt.out.splitlines()
+        out = [line[5:] for line in apt.out if line.startswith("Inst ")]
+        return out.count("\n"), out
 
 Backend = AptGet
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    print("Updates: {}\n\n{}".format(*Backend().updates))

--- a/i3pystatus/updates/cower.py
+++ b/i3pystatus/updates/cower.py
@@ -13,6 +13,12 @@ class Cower(Backend):
     def updates(self):
         command = ["cower", "-u"]
         cower = run_through_shell(command)
-        return cower.out.count('\n')
+        return cower.out.count('\n'), cower.out
 
 Backend = Cower
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    print("Updates: {}\n\n{}".format(*Backend().updates))

--- a/i3pystatus/updates/dnf.py
+++ b/i3pystatus/updates/dnf.py
@@ -17,8 +17,10 @@ class Dnf(Backend):
     def updates(self):
         command = ["dnf", "check-update"]
         dnf = run_through_shell(command)
-        raw = dnf.out
+        if dnf.err:
+            return "?", dnf.err
 
+        raw = dnf.out
         update_count = 0
         if dnf.rc == 100:
             lines = raw.splitlines()[2:]

--- a/i3pystatus/updates/dnf.py
+++ b/i3pystatus/updates/dnf.py
@@ -1,11 +1,14 @@
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.updates import Backend
-from re import split
+from re import split, sub
 
 
 class Dnf(Backend):
     """
-    Gets update count for RPM-based distributions with dnf.
+    Gets updates for RPM-based distributions with `dnf check-update`.
+
+    The notification body consists of the status line followed by the package
+    name and version for each update.
 
     https://dnf.readthedocs.org/en/latest/command_ref.html#check-update-command
     """
@@ -14,12 +17,14 @@ class Dnf(Backend):
     def updates(self):
         command = ["dnf", "check-update"]
         dnf = run_through_shell(command)
+        raw = dnf.out
 
         update_count = 0
         if dnf.rc == 100:
-            lines = dnf.out.splitlines()[2:]
+            lines = raw.splitlines()[2:]
             lines = [l for l in lines if len(split("\s{2,}", l.rstrip())) == 3]
             update_count = len(lines)
-        return update_count
+        notif_body = sub(r"(\S+)\s+(\S+)\s+\S+\s*\n", r"\1: \2\n", raw)
+        return update_count, notif_body
 
 Backend = Dnf

--- a/i3pystatus/updates/dnf.py
+++ b/i3pystatus/updates/dnf.py
@@ -35,5 +35,4 @@ if __name__ == "__main__":
     """
     Call this module directly; Print the update count and notification body.
     """
-    dnf = Dnf()
-    print("Updates: {}\n\n{}".format(*dnf.updates))
+    print("Updates: {}\n\n{}".format(*Backend().updates))

--- a/i3pystatus/updates/dnf.py
+++ b/i3pystatus/updates/dnf.py
@@ -24,7 +24,7 @@ class Dnf(Backend):
         update_count = 0
         if dnf.rc == 100:
             lines = raw.splitlines()[2:]
-            lines = [l for l in lines if len(split("\s{2,}", l.rstrip())) == 3]
+            lines = [l for l in lines if len(split("\s+", l.rstrip())) == 3]
             update_count = len(lines)
         notif_body = sub(r"(\S+)\s+(\S+)\s+\S+\s*\n", r"\1: \2\n", raw)
         return update_count, notif_body

--- a/i3pystatus/updates/dnf.py
+++ b/i3pystatus/updates/dnf.py
@@ -28,3 +28,10 @@ class Dnf(Backend):
         return update_count, notif_body
 
 Backend = Dnf
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    dnf = Dnf()
+    print("Updates: {}\n\n{}".format(*dnf.updates))

--- a/i3pystatus/updates/pacman.py
+++ b/i3pystatus/updates/pacman.py
@@ -12,6 +12,12 @@ class Pacman(Backend):
     def updates(self):
         command = ["checkupdates"]
         checkupdates = run_through_shell(command)
-        return checkupdates.out.count('\n')
+        return checkupdates.out.count("\n"), checkupdates.out
 
 Backend = Pacman
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    print("Updates: {}\n\n{}".format(*Backend().updates))

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -25,8 +25,15 @@ class Yaourt(Backend):
     def updates(self):
         command = ["yaourt", "-Qua"]
         checkupdates = run_through_shell(command)
+        out = checkupdates.out
         if(self.aur_only):
-            return len(re.findall("^aur/", checkupdates.out, flags=re.M))
-        return checkupdates.out.count("\n")
+            out = [line for line in out if line.startswith("aur")]
+        return out.count("\n"), out
 
 Backend = Yaourt
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    print("Updates: {}\n\n{}".format(*Backend().updates))

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -1,4 +1,3 @@
-import re
 from i3pystatus.core.command import run_through_shell
 from i3pystatus.updates import Backend
 
@@ -6,16 +5,22 @@ from i3pystatus.updates import Backend
 class Yaourt(Backend):
     """
     This module counts the available updates using yaourt.
-    By default it will only count aur packages. Thus it can be used with the pacman backend like this:
+    By default it will only count aur packages. Thus it can be used with the
+    pacman backend like this:
 
-    from i3pystatus.updates import pacman, yaourt
-    status.register("updates", backends = [pacman.Pacman(), yaourt.Yaourt()])
+    .. code-block:: python
 
-    If you want to count both pacman and aur packages with this module you can set the variable
-    count_only_aur = False like this:
+        from i3pystatus.updates import pacman, yaourt
+        status.register("updates", backends = \
+[pacman.Pacman(), yaourt.Yaourt()])
 
-    from i3pystatus.updates import yaourt
-    status.register("updates", backends = [yaourt.Yaourt(False)])
+    If you want to count both pacman and aur packages with this module you can
+    set the variable count_only_aur = False like this:
+
+    .. code-block:: python
+
+        from i3pystatus.updates import yaourt
+        status.register("updates", backends = [yaourt.Yaourt(False)])
     """
 
     def __init__(self, aur_only=True):


### PR DESCRIPTION
Working for DNF, re. #364.

The other backends should be updated to return, as the second element of a tuple, what they want in the notification body. (I'm not prepared to do them myself.) With no changes, the notif balloon should be OK but will only have the count.

![updates-dnf](https://cloud.githubusercontent.com/assets/3425234/14408420/56e9594a-fea9-11e5-93d6-ddd92fa572a5.png)

