### PR TITLE
MPD KeyError fix at end of playback

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -114,7 +114,7 @@ class MPD(IntervalModule):
             "bitrate": int(status.get("bitrate", 0)),
         }
 
-        if not fdict["title"]:
+        if not fdict["title"] and "file" in currentsong:
             fdict["filename"] = '.'.join(
                 basename(currentsong["file"]).split('.')[:-1])
         else:


### PR DESCRIPTION
Bug: Use the mpd module, and let a playlist play to the end. You'll get `MPD: KeyError: 'file'`. (Just stopping playback doesn't trigger it.)

This is a fix.

Seems unrelated to #207, #244, #249, and #251 