### PR TITLE
Catch another odd weather.com weather condition

### DIFF
--- a/i3pystatus/weather/__init__.py
+++ b/i3pystatus/weather/__init__.py
@@ -121,7 +121,7 @@ class Weather(IntervalModule):
                     condition = 'Partly Cloudy'
                 else:
                     condition = 'Cloudy'
-            elif 'thunder' in condition_lc:
+            elif 'thunder' in condition_lc or 't-storm' in condition_lc:
                 condition = 'Thunderstorm'
             elif 'snow' in condition_lc:
                 condition = 'Snow'


### PR DESCRIPTION
This properly colorizes when there is a thunderstorm and the weather.com
API response defines the current weather condition as "T-Storm". No idea
why they decide to do this, it's definitely not for brevity as they have
a "Thunderstorms in the Vicinity" weather condition as well. Just a
weird quirk of their API, I guess.