### PR TITLE
openfiles: module to report open file handle count

### DIFF
--- a/i3pystatus/openfiles.py
+++ b/i3pystatus/openfiles.py
@@ -18,8 +18,9 @@ class Openfiles(IntervalModule):
 
     def run(self):
 
-        cur_filenr = open(self.filenr_path, 'r').readlines()
-        openfiles, unused, maxfiles = cur_filenr[0].split()
+        cur_filenr = open(self.filenr_path, 'r')
+        openfiles, unused, maxfiles = cur_filenr.readlines()[0].split()
+        cur_filenr.close()
 
         cdict = {'openfiles': openfiles,
                  'maxfiles': maxfiles}

--- a/i3pystatus/openfiles.py
+++ b/i3pystatus/openfiles.py
@@ -1,0 +1,30 @@
+from i3pystatus import IntervalModule
+
+
+class Openfiles(IntervalModule):
+    """
+    Displays the current/max open files.
+    """
+
+    settings = (
+        ("filenr_path", "Location to file-nr (usually /proc/sys/fs/file-nr"),
+        "color",
+        "format"
+    )
+    color = 'FFFFFF'
+    interval = 30
+    filenr_path = '/proc/sys/fs/file-nr'
+    format = "open/max: {openfiles}/{maxfiles}"
+
+    def run(self):
+
+        cur_filenr = open(self.filenr_path, 'r').readlines()
+        openfiles, unused, maxfiles = cur_filenr[0].split()
+
+        cdict = {'openfiles': openfiles,
+                 'maxfiles': maxfiles}
+
+        self.output = {
+            "full_text": self.format.format(**cdict),
+            "color": self.color
+        }

--- a/tests/test_openfiles.py
+++ b/tests/test_openfiles.py
@@ -1,0 +1,29 @@
+"""
+Basic test for the openfiles module
+"""
+
+import unittest
+from tempfile import TemporaryDirectory
+from shutil import copyfile
+from i3pystatus import openfiles
+
+
+class OpenfilesTest(unittest.TestCase):
+
+    def test_openfiles(self):
+        """
+        Test output of open files
+        """
+        # copy file-nr so we have a known/unchanged source file
+        with TemporaryDirectory() as tmpdirname:
+            copyfile('/proc/sys/fs/file-nr', tmpdirname + '/file-nr')
+            cur_filenr = open(tmpdirname + '/file-nr', 'r')
+            openfilehandles, ununsed, maxfiles = cur_filenr.readlines()[0].split()
+            cur_filenr.close()
+            i3openfiles = openfiles.Openfiles(filenr_path=tmpdirname + '/file-nr')
+            i3openfiles.run()
+            self.assertTrue(i3openfiles.output['full_text'] == 'open/max: %s/%s' % (openfilehandles, maxfiles))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This module will display the current open file handles and the kernel
setting for max open file handles.  This is particularly useful when
running applications that like to grab a lot of file handles to help
monitor if/when your system may run out of available file handles.