### PR TITLE
Fix imap connection lost

### DIFF
--- a/i3pystatus/mail/imap.py
+++ b/i3pystatus/mail/imap.py
@@ -1,8 +1,7 @@
-import sys
 import imaplib
+import socket
 
 from i3pystatus.mail import Backend
-from i3pystatus.core.util import internet
 
 
 class IMAP(Backend):
@@ -33,20 +32,30 @@ class IMAP(Backend):
             self.imap_class = imaplib.IMAP4_SSL
 
     def get_connection(self):
+        if self.connection:
+            try:
+                self.connection.select(self.mailbox)
+            except socket.error:
+                # NOTE(sileht): retry just once if the connection have been
+                # broken to ensure this is not a sporadic connection lost.
+                # Like wifi reconnect, sleep wake up
+                try:
+                    self.connection.logout()
+                except socket.error:
+                    pass
+                self.connection = None
+
         if not self.connection:
             self.connection = self.imap_class(self.host, self.port)
             self.connection.login(self.username, self.password)
             self.connection.select(self.mailbox)
 
-        self.connection.select(self.mailbox)
-
         return self.connection
 
     @property
     def unread(self):
-        if internet():
-            conn = self.get_connection()
-            self.last = len(conn.search(None, "UnSeen")[1][0].split())
+        conn = self.get_connection()
+        self.last = len(conn.search(None, "UnSeen")[1][0].split())
         return self.last
 
 


### PR DESCRIPTION
Hi,

Nothing in imap mail backend reinit the imap connection
when this one is lost, and then the backend always output "socket.error:..."

This change fixes that by cleanup the connection object when
connection is lost so get_connection() will recreate a new one.

This also remove the unless utils.internet() checks already done by
Mail().run()

Cheers,