### PR TITLE
gpu_temp: add "display_if" setting

### DIFF
--- a/i3pystatus/gpu_temp.py
+++ b/i3pystatus/gpu_temp.py
@@ -15,6 +15,7 @@ class GPUTemperature(IntervalModule):
 
     settings = (
         ("format", "format string used for output. {temp} is the temperature in integer degrees celsius"),
+        ("display_if", "snippet that gets evaluated. if true, displays the module output"),
         "color",
         "alert_temp",
         "alert_color",
@@ -23,12 +24,14 @@ class GPUTemperature(IntervalModule):
     color = "#FFFFFF"
     alert_temp = 90
     alert_color = "#FF0000"
+    display_if = True
 
     def run(self):
         temp = gpu.query_nvidia_smi().temp
         temp_alert = temp is None or temp >= self.alert_temp
 
-        self.output = {
-            "full_text": self.format.format(temp=temp),
-            "color": self.color if not temp_alert else self.alert_color,
-        }
+        if eval(self.display_if):
+            self.output = {
+                "full_text": self.format.format(temp=temp),
+                "color": self.color if not temp_alert else self.alert_color,
+            }


### PR DESCRIPTION
Adds a "display_if" setting to the gpu_temp module that allows the
output to be squelched unless some snippet has been evaluated as true.