### PR TITLE
add weekcal module

### DIFF
--- a/i3pystatus/weekcal.py
+++ b/i3pystatus/weekcal.py
@@ -1,0 +1,70 @@
+from calendar import Calendar
+from datetime import date, timedelta
+
+from i3pystatus import IntervalModule
+
+
+class WeekCal(IntervalModule):
+    """
+    Displays the days of the current week as they would be represented on a calendar sheet,
+    with the current day highlighted.
+    By default, the current day of week is displayed in the front, and the month and year are
+    displayed in the back.
+
+    Example: ``Sat  16 17 18 19 20[21]22  May 2016``
+    """
+
+    settings = (
+        ("startofweek", "First day of the week (0 = Monday, 6 = Sunday), defaults to 0."),
+        ("prefixformat", "Prefix in strftime-format"),
+        ("suffixformat", "Suffix in strftime-format"),
+        ("todayhighlight", "Characters to highlight today's date"),
+    )
+    startofweek = 0
+    interval = 30
+    prefixformat = "%a"
+    suffixformat = "%b %Y"
+    todayhighlight = "[]"
+
+    def __init__(self, *args, **kwargs):
+        IntervalModule.__init__(self, *args, **kwargs)
+        self.cal = Calendar(self.startofweek)
+
+    def run(self):
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        outstr = today.strftime(self.prefixformat) + " "
+
+        weekdays = self.cal.iterweekdays()
+        if today.weekday() == self.startofweek:
+            outstr += self.todayhighlight[0]
+        else:
+            outstr += " "
+
+        nextweek = False  # keep track of offset if week doesn't start on monday
+
+        for w in weekdays:
+            if w == 0 and self.startofweek != 0:
+                nextweek = True
+            if nextweek and today.weekday() >= self.startofweek:
+                w += 7
+            elif not nextweek and today.weekday() < self.startofweek:
+                w -= 7
+
+            weekday_offset = today.weekday() - w
+            weekday_delta = timedelta(days=weekday_offset)
+            weekday = today - weekday_delta
+            if weekday == yesterday:
+                outstr += weekday.strftime("%d") + self.todayhighlight[0]
+            elif weekday == today:
+                outstr += weekday.strftime("%d") + self.todayhighlight[1]
+            else:
+                outstr += weekday.strftime("%d ")
+
+        outstr += " " + today.strftime(self.suffixformat)
+
+        self.output = {
+            "full_text": outstr,
+            "urgent": False,
+        }

--- a/i3pystatus/weekcal.py
+++ b/i3pystatus/weekcal.py
@@ -24,7 +24,7 @@ class WeekCal(IntervalModule):
     interval = 30
     prefixformat = "%a"
     suffixformat = "%b %Y"
-    todayhighlight = "[]"
+    todayhighlight = ("[", "]")
 
     def __init__(self, *args, **kwargs):
         IntervalModule.__init__(self, *args, **kwargs)


### PR DESCRIPTION
I often find myself opening a console and using `cal` to find out things like "which day is the 15th" or "what date was this tuesday". So much that I wanted to permanently have that info in my i3pystatus. This module displays an entry like this: `Sat  16 17 18 19 20[21]22  May 2016`