### PR TITLE
shell: add hide_if_empty setting

### DIFF
--- a/i3pystatus/shell.py
+++ b/i3pystatus/shell.py
@@ -19,8 +19,11 @@ class Shell(IntervalModule):
         ("command", "command to be executed"),
         ("color", "standard color"),
         ("error_color", "color to use when non zero exit code is returned"),
+        ("hide_if_empty", "Hide output when zero exit code and output is empty"),
         "format"
     )
+
+    hide_if_empty = False
 
     required = ("command",)
     format = "{output}"
@@ -30,6 +33,10 @@ class Shell(IntervalModule):
 
         if retvalue != 0:
             self.logger.error(stderr if stderr else "Unknown error")
+        else:
+            if self.hide_if_empty and not out:
+                self.output = None
+                return
 
         if out:
             out = out.replace("\n", " ").strip()


### PR DESCRIPTION
This PR adds `hide_if_empty` setting to shell module.
This setting hides status code output when the command successful and the output is empty.
It is useful for commands which succeed with empty output, for example [netctl-auto current](https://git.archlinux.org/netctl.git/tree/docs/netctl-auto.1.txt) returns 0 with empty when there is no active profile.