### PR TITLE
imap - Catch socket.gaierror if no internet connection is available.

### DIFF
--- a/i3pystatus/mail/imap.py
+++ b/i3pystatus/mail/imap.py
@@ -54,9 +54,14 @@ class IMAP(Backend):
 
     @property
     def unread(self):
-        conn = self.get_connection()
-        self.last = len(conn.search(None, "UnSeen")[1][0].split())
-        return self.last
+        try:
+            conn = self.get_connection()
+        except socket.gaierror:
+            pass
+        else:
+            self.last = len(conn.search(None, "UnSeen")[1][0].split())
+        finally:
+            return self.last
 
 
 Backend = IMAP


### PR DESCRIPTION
This fixes a regression introduced in 2d7b3afaca97a3e6a115c077586d0a9fb9daf8b2.