### PR TITLE
Treat i3pystatus as launcher

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,6 +123,16 @@ Also change your i3wm config to the following:
 .. note:: Don't name your config file ``i3pystatus.py``, as it would
     make ``i3pystatus`` un-importable and lead to errors.
 
+Another way to launch your configuration file is to use ``i3pystatus`` script
+from installation:
+
+.. code:: bash
+
+    i3pystatus -c ~/.path/to/your/config/file.py
+
+If no arguments were provided, ``i3pystatus`` script works as an example of
+``Clock`` module.
+
 .. _credentials:
 
 Credentials

--- a/i3pystatus/__init__.py
+++ b/i3pystatus/__init__.py
@@ -5,6 +5,8 @@ from i3pystatus.core.modules import Module, IntervalModule
 from i3pystatus.core.settings import SettingsBase
 from i3pystatus.core.util import formatp, get_module
 
+import argparse
+import imp
 import logging
 import os
 
@@ -25,9 +27,23 @@ logger.addHandler(handler)
 logger.setLevel(logging.CRITICAL)
 
 
-def main():
+def clock_example():
     from i3pystatus.clock import Clock
 
     status = Status()
     status.register(Clock())
     status.run()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='''
+        run i3pystatus configuration file. Starts i3pystatus clock example if no arguments were provided
+    ''')
+    parser.add_argument('-c', '--config', help='path to configuration file', default=None, required=False)
+    args = parser.parse_args()
+
+    if args.config:
+        module_name = "i3pystatus-config"
+        imp.load_source(module_name, args.config)
+    else:
+        clock_example()


### PR DESCRIPTION
Hi!
I'd like to use i3pystatus python executable as launcher for configuration files:
```bash
i3pystatus -c ~/.config/i3/status-config.py
```
The main reason is that executables in my system (NixOS) has own interpreter: from ld-linux.so for binaries to shabang interpter for scripts. Another reason is that some well-knonw status applications have this functionality: xmobar, conky, i3status. And the last one: I can install i3pystatus inside virtualenv and launch configuration files directly with the help of `i3pystatus -c`.