### PR TITLE
If imaplib2 is installed use the IDLE feature of IMAP to avoid polling

### DIFF
--- a/i3pystatus/mail/imap.py
+++ b/i3pystatus/mail/imap.py
@@ -56,6 +56,7 @@ class Idler(object):
         self.stop()
         self.start()
 
+
 class IMAP(Backend):
     """
     Checks for mail on a IMAP server


### PR DESCRIPTION
I sort of copied the code together, without really understanding what goes on in the thread checking for mail. It seems to work, though. 

Ideally, there should be some cleanup such as 

    idler.stop()
    idler.join()
    self.conn.close()
    self.conn.logout()

after the script exits, I just don't know where to put those. Also, I moved the login command to the `init` function. I am not sure if this breaks anything when suspending the computer or temporarily losing connection, as I don't know how i3pystatus handles connection losses. 

Feel free to change stuff so it is more stable.