### PR TITLE
Change default weather icon for thunderstorm, add "Fog" weather condition

### DIFF
--- a/i3pystatus/weather/__init__.py
+++ b/i3pystatus/weather/__init__.py
@@ -89,7 +89,7 @@ class Weather(IntervalModule):
         'Cloudy': (u'\u2601', '#f8f8ff'),
         'Partly Cloudy': (u'\u2601', '#f8f8ff'),  # \u26c5 is not in many fonts
         'Rainy': (u'\u26c8', '#cbd2c0'),
-        'Thunderstorm': (u'\u26c8', '#cbd2c0'),
+        'Thunderstorm': (u'\u26a1', '#cbd2c0'),
         'Sunny': (u'\u2600', '#ffff00'),
         'Snow': (u'\u2603', '#ffffff'),
         'default': ('', None),

--- a/i3pystatus/weather/__init__.py
+++ b/i3pystatus/weather/__init__.py
@@ -88,7 +88,7 @@ class Weather(IntervalModule):
         'Cloudy': (u'\u2601', '#f8f8ff'),
         'Partly Cloudy': (u'\u2601', '#f8f8ff'),  # \u26c5 is not in many fonts
         'Rainy': (u'\u26c8', '#cbd2c0'),
-        'Thunderstorm': (u'\u03de', '#cbd2c0'),
+        'Thunderstorm': (u'\u26c8', '#cbd2c0'),
         'Sunny': (u'\u2600', '#ffff00'),
         'Snow': (u'\u2603', '#ffffff'),
         'default': ('', None),

--- a/i3pystatus/weather/__init__.py
+++ b/i3pystatus/weather/__init__.py
@@ -85,6 +85,7 @@ class Weather(IntervalModule):
     colorize = False
     color_icons = {
         'Fair': (u'\u263c', '#ffcc00'),
+        'Fog': (u'', '#949494'),
         'Cloudy': (u'\u2601', '#f8f8ff'),
         'Partly Cloudy': (u'\u2601', '#f8f8ff'),  # \u26c5 is not in many fonts
         'Rainy': (u'\u26c8', '#cbd2c0'),
@@ -131,6 +132,8 @@ class Weather(IntervalModule):
                 condition = 'Sunny'
             elif 'clear' in condition_lc or 'fair' in condition_lc:
                 condition = 'Fair'
+            elif 'fog' in condition_lc:
+                condition = 'Fog'
 
         return self.color_icons['default'] \
             if condition not in self.color_icons \


### PR DESCRIPTION
I had added this to be able to use a different icon for thunderstorms,
which were at the time not even being detected as a weather condition
and were just falling back to the default (i.e. no colorization nor
icon). However, the only thunder/lightning unicode icon that is widely
available is too tall, leading to the entire module's text being
vertically-aligned on a different plane from the rest of the modules in
the status bar.

This commit changes the default icon to the same one used for "Rainy"
conditions, while preserving it as a distinct weather type so that
others can still use their own icon if they so choose.


**EDIT: Thanks to @ncoop I changed this PR to include a better "lightning" unicode icon.**