### PR TITLE
Pulseaudio: Update status immediately when volume changes

### DIFF
--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -88,6 +88,10 @@ class Module(SettingsBase):
     def run(self):
         pass
 
+    def send_output(self):
+        """Send a status update with the current module output"""
+        self.__status_handler.io.async_refresh()
+
     def __log_button_event(self, button, cb, args, action, **kwargs):
         msg = "{}: button={}, cb='{}', args={}, kwargs={}, type='{}'".format(
             self.__name__, button, cb, args, kwargs, action)

--- a/i3pystatus/pulseaudio/__init__.py
+++ b/i3pystatus/pulseaudio/__init__.py
@@ -177,6 +177,8 @@ class PulseAudio(Module, ColorRangeModule):
                     volume_bar=volume_bar),
             }
 
+            self.send_output()
+
     def change_sink(self):
         curr_sink = self.sink
         sinks = list(s.split()[1] for s in self.sinks)


### PR DESCRIPTION
Volume changes may occur externally (e.g. through pactl bound to media
keys) or through mouse interaction. The new volume is received
asynchronously but can only be outputted at the next status poll,
causing a small delay.

Introduce Module.send_output() to allow a module to send its output
without delay. Invoke this method in the Pulseaudio sink info callback.