### PR TITLE
Catch ConnectionResetError when making API request

### DIFF
--- a/i3pystatus/scores/__init__.py
+++ b/i3pystatus/scores/__init__.py
@@ -76,7 +76,7 @@ class ScoresBackend(SettingsBase):
                 exc.code, exc.reason, exc.url,
             )
             return {}
-        except URLError as exc:
+        except (ConnectionResetError, URLError) as exc:
             self.logger.critical('Error making request to %s: %s', url, exc)
             return {}
 

--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -269,7 +269,7 @@ class MLB(ScoresBackend):
             ret['delay'] = game.get('reason', 'Unknown')
         elif ret['status'] == 'postponed':
             ret['postponed'] = game.get('reason', 'Unknown Reason')
-        elif ret['status'] == 'game_over':
+        elif ret['status'] in ('game_over', 'completed_early'):
             ret['status'] = 'final'
         elif ret['status'] not in ('in_progress', 'final'):
             ret['status'] = 'pregame'
@@ -277,7 +277,7 @@ class MLB(ScoresBackend):
         try:
             inning = game.get('inning', '0')
             ret['extra_innings'] = inning \
-                if ret['status'] == 'final' and int(inning) > 9 \
+                if ret['status'] == 'final' and int(inning) != 9 \
                 else ''
         except ValueError:
             ret['extra_innings'] = ''


### PR DESCRIPTION
Caught this traceback in the log when an update failed to complete. Also
added a generic Exception catch-all.

EDIT: Also fixed rain-shortened MLB games from being misidentified as
in a pregame state, when they should have been designated as final.