### PR TITLE
Fix wrong dictionary key

### DIFF
--- a/i3pystatus/cpu_usage.py
+++ b/i3pystatus/cpu_usage.py
@@ -113,7 +113,7 @@ class CpuUsage(IntervalModule):
 
     def run(self):
         usage = self.get_usage()
-        usage['format_all'] = self.gen_format_all(usage)
+        usage['usage_all'] = self.gen_format_all(usage)
 
         # for backward compatibility
         usage['usage'] = usage['usage_cpu']


### PR DESCRIPTION
Fixes the problem that one had to use ``{format_all}`` while the documentation clearly states ``{usage_all}``