### PR TITLE
Add format option, logic to handle suspended MLB games

### DIFF
--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -109,6 +109,7 @@ class MLB(ScoresBackend):
         ('format_in_progress', 'Format used when the game is in progress'),
         ('format_final', 'Format used when the game is complete'),
         ('format_postponed', 'Format used when the game has been postponed'),
+        ('format_suspended', 'Format used when the game has been suspended'),
         ('inning_top', 'Value for the ``{top_bottom}`` formatter when game '
                        'is in the top half of an inning'),
         ('inning_bottom', 'Value for the ``{top_bottom}`` formatter when game '
@@ -168,7 +169,7 @@ class MLB(ScoresBackend):
     }
 
     _valid_teams = [x for x in _default_colors]
-    _valid_display_order = ['in_progress', 'final', 'postponed', 'pregame']
+    _valid_display_order = ['in_progress', 'suspended', 'final', 'postponed', 'pregame']
 
     display_order = _valid_display_order
     format_no_games = 'MLB: No games'
@@ -176,6 +177,7 @@ class MLB(ScoresBackend):
     format_in_progress = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} {away_score}, [{home_favorite} ]{home_abbrev} {home_score} ({top_bottom} {inning}, {outs} Out)[ ({delay} Delay)]'
     format_final = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} {away_score} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} {home_score} ({home_wins}-{home_losses}) (Final[/{extra_innings}])'
     format_postponed = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} ({home_wins}-{home_losses}) (PPD: {postponed})'
+    format_suspended = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} ({home_wins}-{home_losses}) (Suspended: {suspended})'
     inning_top = 'Top'
     inning_bottom = 'Bot'
     team_colors = _default_colors
@@ -258,7 +260,7 @@ class MLB(ScoresBackend):
             # pregame
             ret['status'] = 'pregame'
 
-        for key in ('delay', 'postponed'):
+        for key in ('delay', 'postponed', 'suspended'):
             ret[key] = ''
 
         if ret['status'] == 'delayed_start':
@@ -269,6 +271,8 @@ class MLB(ScoresBackend):
             ret['delay'] = game.get('reason', 'Unknown')
         elif ret['status'] == 'postponed':
             ret['postponed'] = game.get('reason', 'Unknown Reason')
+        elif ret['status'] == 'suspended':
+            ret['suspended'] = game.get('reason', 'Unknown Reason')
         elif ret['status'] in ('game_over', 'completed_early'):
             ret['status'] = 'final'
         elif ret['status'] not in ('in_progress', 'final'):
@@ -299,10 +303,25 @@ class MLB(ScoresBackend):
                 'US/Eastern'
             )
         )
-        game_time_str = ' '.join((
-            game.get('time_date', ''),
-            game.get('ampm', '')
-        ))
+
+        date_and_time = []
+        if 'resume_time_date' in game and game['resume_time_date']:
+            date_and_time.append(game['resume_time_date'])
+        elif 'time_date' in game and game['time_date']:
+            date_and_time.append(game['time_date'])
+        else:
+            keys = ('original_date', 'time')
+            if all(key in game for key in keys):
+                for key in keys:
+                    if game[key]:
+                        date_and_time.append(game[key])
+        if 'resume_ampm' in game and game['resume_ampm']:
+            date_and_time.append(game['resume_ampm'])
+        elif 'ampm' in game and game['ampm']:
+            date_and_time.append(game['ampm'])
+
+        game_time_str = ' '.join(date_and_time)
+
         try:
             game_time = datetime.strptime(game_time_str, '%Y/%m/%d %I:%M %p')
         except ValueError as exc:
@@ -317,7 +336,7 @@ class MLB(ScoresBackend):
                 game['id'],
                 exc_info=True
             )
-            game_time = datetime.datetime(1970, 1, 1)
+            game_time = datetime(1970, 1, 1)
 
         ret['start_time'] = game_tz.localize(game_time).astimezone()
 

--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -177,7 +177,7 @@ class MLB(ScoresBackend):
     format_in_progress = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} {away_score}, [{home_favorite} ]{home_abbrev} {home_score} ({top_bottom} {inning}, {outs} Out)[ ({delay} Delay)]'
     format_final = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} {away_score} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} {home_score} ({home_wins}-{home_losses}) (Final[/{extra_innings}])'
     format_postponed = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} ({home_wins}-{home_losses}) (PPD: {postponed})'
-    format_suspended = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} ({home_wins}-{home_losses}) (Suspended: {suspended})'
+    format_suspended = '[{scroll} ]MLB: [{away_favorite} ]{away_abbrev} {away_score} ({away_wins}-{away_losses}) at [{home_favorite} ]{home_abbrev} {home_score} ({home_wins}-{home_losses}) (Suspended: {suspended})'
     inning_top = 'Top'
     inning_bottom = 'Bot'
     team_colors = _default_colors


### PR DESCRIPTION
Tonight's game was the first time I've seen the API return from a
suspended game. I added a separate format option for it.

I've also fixed date/time detection. The API returns different fields for if
a game ended after midnight eastern, and also different ones when a game
is suspended.