### PR TITLE
Fix network module error with netifaces 0.10.5

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -13,16 +13,8 @@ def count_bits(integer):
     return bits
 
 
-def v6_to_int(v6):
-    return int(v6.replace(":", ""), 16)
-
-
-def prefix6(mask):
-    return count_bits(v6_to_int(mask))
-
-
-def cidr6(addr, mask):
-    return "{addr}/{bits}".format(addr=addr, bits=prefix6(mask))
+def cidr6(addr, bits):
+    return "{addr}/{bits}".format(addr=addr, bits=bits)
 
 
 def v4_to_int(v4):
@@ -126,8 +118,9 @@ class NetworkInfo:
         if netifaces.AF_INET6 in network_info:
             for v6 in network_info[netifaces.AF_INET6]:
                 info["v6"] = v6["addr"]
-                info["v6mask"] = v6["netmask"]
-                info["v6cidr"] = cidr6(v6["addr"], v6["netmask"])
+                mask, bits = v6["netmask"].split("/")
+                info["v6mask"] = mask
+                info["v6cidr"] = cidr6(v6["addr"], bits)
                 if not v6["addr"].startswith("fe80::"):  # prefer non link-local addresses
                     break
         return info


### PR DESCRIPTION
[netifaces 0.10.5](https://bitbucket.org/al45tair/netifaces/src/dc7c8e888476d3af7f8370bca8a2e900eaa3b1c8/CHANGELOG?at=release_0_10_5&fileviewer=file-view-default#CHANGELOG-10) uses CIDR notation for IPv6 netmasks.
This PR follow the change of netifaces.