### PR TITLE
openstack_vms: update novaclient auth

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ MOCK_MODULES = [
     "requests",
     "bs4",
     "dota2py",
-    "novaclient.v2",
+    "novaclient",
     "speedtest_cli",
     "pyzabbix",
     "vk",

--- a/i3pystatus/openstack_vms.py
+++ b/i3pystatus/openstack_vms.py
@@ -1,6 +1,6 @@
 from i3pystatus import IntervalModule
 # requires python-novaclient
-from novaclient.v2 import client
+from novaclient import client
 import webbrowser
 
 
@@ -35,6 +35,7 @@ class Openstack_vms(IntervalModule):
 
     def run(self):
         nclient = client.Client(
+            '2.0',
             self.username,
             self.password,
             self.tenant_name,


### PR DESCRIPTION
The openstack novaclient has updated it's auth mechanism, deprecating
the method used in this module.  This patch updates the novaclient
authentication call to leverage this new auth method.