### PR TITLE
dota2wins: fix win% reporting

### DIFF
--- a/i3pystatus/dota2wins.py
+++ b/i3pystatus/dota2wins.py
@@ -102,10 +102,8 @@ class Dota2wins(IntervalModule):
             "wins": wins,
             "losses": losses,
             "win_percent": win_percent,
-            "win_percent": "%.2f" % win_percent,
         }
 
-        self.data = cdict
         self.output = {
             "full_text": self.format.format(**cdict),
             "color": color


### PR DESCRIPTION
Somehow I accidentially had 2 win_percent values being set in the cdict,
one of which was a string that breaks when you try to round off the
remainder.  Also cleanup unused "self.data" variable.