### PR TITLE
Fix net_speed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ MOCK_MODULES = [
     "bs4",
     "dota2py",
     "novaclient",
-    "speedtest_cli",
+    "speedtest",
     "pyzabbix",
     "vk",
     "google-api-python-client",

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -22,7 +22,7 @@ class NetSpeed(IntervalModule):
     color = "#FFFFFF"
     interval = 300
     units = 'bits'
-    format = "↓{speed_down:.2f}{down_units} ↑{speed_up:.2f}{up_units} ({hosting_provider})"
+    format = "↓{speed_down:.1f}{down_units} ↑{speed_up:.1f}{up_units} ({hosting_provider})"
 
     def form_b(self, n: float)->tuple:
         """

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -13,6 +13,8 @@ class NetSpeed(IntervalModule):
     """
     Attempts to provide an estimation of internet speeds.
     Requires: speedtest-cli/modularize-2
+    speedtest-cli/modularize-2 can be installed using pip:
+    `pip install https://github.com/sivel/speedtest-cli/archive/modularize-2.zip`
     """
 
     settings = (
@@ -26,7 +28,7 @@ class NetSpeed(IntervalModule):
 
     def form_b(self, n: float)->tuple:
         """
-        formates a bps as bps/kbps/mbps/gbps etc
+        formats a bps as bps/kbps/mbps/gbps etc
         handles whether its meant to be in bytes
         :param n: input float
         :rtype tuple:

--- a/i3pystatus/net_speed.py
+++ b/i3pystatus/net_speed.py
@@ -14,7 +14,7 @@ class NetSpeed(IntervalModule):
     Attempts to provide an estimation of internet speeds.
     Requires: speedtest-cli/modularize-2
     speedtest-cli/modularize-2 can be installed using pip:
-    `pip install https://github.com/sivel/speedtest-cli/archive/modularize-2.zip`
+    `pip install git+https://github.com/sivel/speedtest-cli.git@modularize-2`
     """
 
     settings = (


### PR DESCRIPTION
speedtest-cli no longer offers a module interface in the main branch: use speedtest-cli/modularize-2 until it is merged in with master.
I cleaned up net_speed and made it use speedtest-cli properly. It now also gives an indication of upload speed by default.
