### PR TITLE
Fix traceback when notification daemon not running

### DIFF
--- a/i3pystatus/core/desktop.py
+++ b/i3pystatus/core/desktop.py
@@ -68,10 +68,9 @@ else:
             notification.set_urgency(self.URGENCY_LUT[self.urgency])
             try:
                 return notification.show()
-            except Exception as exc:
-                self.logger.error(
+            except Exception:
+                self.logger.exception(
                     'Failed to display desktop notification (is a '
-                    'notification daemon running?)',
-                    exc_info=self.log_level <= logging.DEBUG
+                    'notification daemon running?)'
                 )
                 return False


### PR DESCRIPTION
When a desktop notification is displayed but there is no notification
daemon running, an exception is raised.

This fixes the traceback by adding a logger to the DesktopNotification
class, and logging an error when the exception is caught.

Fixes #453.