### PR TITLE
Pulseaudio: fix non-working decrease_volume()

### DIFF
--- a/i3pystatus/pulseaudio/__init__.py
+++ b/i3pystatus/pulseaudio/__init__.py
@@ -191,10 +191,10 @@ class PulseAudio(Module, ColorRangeModule):
         subprocess.call("pacmd set-default-sink {}".format(sinks[next_sink]).split())
 
     def switch_mute(self):
-        subprocess.call(['pactl', 'set-sink-mute', self.sink, "toggle"])
+        subprocess.call(['pactl', '--', 'set-sink-mute', self.sink, "toggle"])
 
     def increase_volume(self):
-        subprocess.call(['pactl', 'set-sink-volume', self.sink, "+%s%%" % self.step])
+        subprocess.call(['pactl', '--', 'set-sink-volume', self.sink, "+%s%%" % self.step])
 
     def decrease_volume(self):
-        subprocess.call(['pactl', 'set-sink-volume', self.sink, "-%s%%" % self.step])
+        subprocess.call(['pactl', '--', 'set-sink-volume', self.sink, "-%s%%" % self.step])


### PR DESCRIPTION
`pactl` fails to execute this command:
```sh
$ pactl set-sink-volume 1 -5%
pactl: invalid option -- '5'
```
So add a `--` to make `-5%` a positional argument rather than an option
```sh
$ pactl -- set-sink-volume 1 -5%
$
```
Also change switch_mute() and increase_volume() methods to look similar to decrease_volume()