### PR TITLE
online module: Don't fail when offline

### DIFF
--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -373,7 +373,7 @@ class internet:
         try:
             socket.create_connection(cls.address, 1).close()
             return True
-        except OSError:
+        except (OSError, socket.gaierror):
             return False
 
 


### PR DESCRIPTION
If the system is offline, `socket.gaierror` is raised, the module crashes, and shows `offline` indefinitely.

Catch that exception, and return False.