### PR TITLE
network: add next_if_down option

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -286,6 +286,7 @@ class Network(IntervalModule, ColorRangeModule):
         ("round_size", "defines number of digits in round"),
         ("detached_down", "If the interface doesn't exist, display it as if it were down"),
         ("unknown_up", "If the interface is in unknown state, display it as if it were up"),
+        ("next_if_down", "Change to next interface if current one is down"),
     )
 
     interval = 1
@@ -302,6 +303,7 @@ class Network(IntervalModule, ColorRangeModule):
     recv_limit = 2048
     sent_limit = 1024
     separate_color = False
+    next_if_down = False
 
     # Network traffic settings
     divisor = 1024
@@ -409,6 +411,8 @@ class Network(IntervalModule, ColorRangeModule):
         else:
             color = self.color_down
             format_str = self.format_down
+            if self.next_if_down:
+                self.cycle_interface()
 
         network_info = self.network_info.get_info(self.interface)
         format_values.update(network_info)


### PR DESCRIPTION
This option switch to the next interface (using `cycle_interface()` method) if the current one is down.

The use case is to have a more automatic behavior. In my case, I switch between Ethernet and Wi-Fi constantly because of my work, so switching manually tires me.

The behavior with this option on is a little problematic in the case where both interfaces are down (if keeps switching between them). And the default scroll up/scroll down to switch interfaces does not really work unless all interfaces are up. This is why I set this option to default to `False`.

However, if there is some suggestion on how to improve the behavior I am all ears.