### PR TITLE
Glob expansion in backlight

### DIFF
--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -1,6 +1,7 @@
 from i3pystatus.file import File
 from i3pystatus import Module
 from i3pystatus.core.command import run_through_shell
+import glob
 import shutil
 
 
@@ -19,12 +20,14 @@ class Backlight(File):
 
     settings = (
         ("format", "format string, formatters: brightness, max_brightness, percentage"),
-        ("backlight", "backlight, see `/sys/class/backlight/`"),
+        ("backlight",
+            "backlight, see `/sys/class/backlight/`. Supports glob expansion, i.e. `*` matches anything. "
+            "If it matches more than one filename, selects the first one in alphabetical order"),
         "color",
     )
     required = ()
 
-    backlight = "acpi_video0"
+    backlight = "*"
     format = "{brightness}/{max_brightness}"
 
     base_path = "/sys/class/backlight/{backlight}/"
@@ -40,6 +43,7 @@ class Backlight(File):
 
     def init(self):
         self.base_path = self.base_path.format(backlight=self.backlight)
+        self.base_path = sorted(glob.glob(self.base_path))[0]
         self.has_xbacklight = shutil.which("xbacklight") is not None
 
         # xbacklight expects a percentage as parameter. Calculate the percentage


### PR DESCRIPTION
Using the new default setting (`*`), this will match any device found in backlight. Fix #442.