### PR TITLE
Backlight: fix crash in #442

### DIFF
--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -48,7 +48,7 @@ class Backlight(File):
         backlight_entries = sorted(glob.glob(self.base_path))
 
         if len(backlight_entries) == 0:
-            self.run = run_no_backlight
+            self.run = self.run_no_backlight
             super().init()
             return
 

--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -20,6 +20,7 @@ class Backlight(File):
 
     settings = (
         ("format", "format string, formatters: brightness, max_brightness, percentage"),
+        ("format_no_backlight", "format string when no backlight file available"),
         ("backlight",
             "backlight, see `/sys/class/backlight/`. Supports glob expansion, i.e. `*` matches anything. "
             "If it matches more than one filename, selects the first one in alphabetical order"),
@@ -29,6 +30,7 @@ class Backlight(File):
 
     backlight = "*"
     format = "{brightness}/{max_brightness}"
+    format_no_backlight = "No backlight"
 
     base_path = "/sys/class/backlight/{backlight}/"
     components = {
@@ -43,7 +45,12 @@ class Backlight(File):
 
     def init(self):
         self.base_path = self.base_path.format(backlight=self.backlight)
-        self.base_path = sorted(glob.glob(self.base_path))[0]
+        backlight_entries = sorted(glob.glob(self.base_path))
+
+        if len(backlight_entries) == 0:
+            self.run = run_no_backlight
+
+        self.base_path = backlight_entries[0]
         self.has_xbacklight = shutil.which("xbacklight") is not None
 
         # xbacklight expects a percentage as parameter. Calculate the percentage
@@ -58,6 +65,23 @@ class Backlight(File):
                 else:
                     self.step_size = 5  # default?
         super().init()
+
+    def run_no_backlight(self):
+        cdict = {
+            "brightness": -1,
+            "max_brightness": -1,
+            "percentage": -1
+        }
+
+        format = self.format_no_backlight
+        if not format:
+            format = self.format
+
+        self.data = cdict
+        self.output = {
+            "full_text": format.format(**cdict),
+            "color": self.color
+        }
 
     def lighter(self):
         if self.has_xbacklight:

--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -49,6 +49,8 @@ class Backlight(File):
 
         if len(backlight_entries) == 0:
             self.run = run_no_backlight
+            super().init()
+            return
 
         self.base_path = backlight_entries[0]
         self.has_xbacklight = shutil.which("xbacklight") is not None

--- a/tests/test_backlight.py
+++ b/tests/test_backlight.py
@@ -1,0 +1,82 @@
+import i3pystatus.backlight as backlight
+
+import os
+import pytest
+
+from contextlib import contextmanager
+from operator import itemgetter
+from tempfile import TemporaryDirectory
+
+
+@contextmanager
+def setattr_temporarily(obj, attr, value):
+    old_value = getattr(obj, attr)
+    setattr(obj, attr, value)
+    yield
+    setattr(obj, attr, old_value)
+
+
+@pytest.mark.parametrize("backlights_data", [
+    [],
+    [("acpi_video0", 0, 255)],
+    [("acpi_video0", 86, 171)],
+    [("acpi_video0", 255, 255)],
+    [("intel_backlight", 0, 7)],
+    [("intel_backlight", 15, 33)],
+    [("intel_backlight", 79, 255)],
+    [("acpi_video0", 0, 50), ("intel_backlight", 44, 60)],
+    [("acpi_video0", 100, 100), ("intel_backlight", 187, 255)],
+    [("intel_backlight", 87, 88), ("acpi_video0", 150, 150)],
+    [("intel_backlight", 237, 237), ("acpi_video0", 1, 2)],
+])
+@pytest.mark.parametrize("format", [
+    None, "{brightness}/{max_brightness} ({percentage}%)"
+])
+@pytest.mark.parametrize("format_no_backlight", [
+    None, "({percentage}% -- {brightness}) [{max_brightness}]"
+])
+def test_backlight(backlights_data, format, format_no_backlight):
+    print(backlight.Backlight.base_path)
+    with TemporaryDirectory() as tmp_dirname:
+        for (backlight_name, brightness, max_brightness) in backlights_data:
+            backlight_dirname = tmp_dirname + "/" + backlight_name
+            os.mkdir(backlight_dirname)
+
+            with open(backlight_dirname + "/brightness", "w") as f:
+                print(brightness, file=f)
+            with open(backlight_dirname + "/max_brightness", "w") as f:
+                print(max_brightness, file=f)
+
+        if not format:
+            format = backlight.Backlight.format
+        if not format_no_backlight:
+            format_no_backlight = backlight.Backlight.format_no_backlight
+            if not format_no_backlight:
+                format_no_backlight = format
+
+        with setattr_temporarily(backlight.Backlight, 'base_path', tmp_dirname + "/{backlight}/"):
+            i3backlight = backlight.Backlight(
+                format=format,
+                format_no_backlight=format_no_backlight)
+
+        i3backlight.run()
+
+        if len(backlights_data) == 0:
+            used_format = format_no_backlight
+            cdict = {
+                "brightness": -1,
+                "max_brightness": -1,
+                "percentage": -1
+            }
+        else:
+            backlights_data = sorted(backlights_data, key=itemgetter(0))
+            (_, brightness, max_brightness) = backlights_data[0]
+
+            used_format = format
+            cdict = {
+                "brightness": brightness,
+                "max_brightness": max_brightness,
+                "percentage": round((brightness / max_brightness) * 100)
+            }
+
+        assert i3backlight.output["full_text"] == used_format.format(**cdict)


### PR DESCRIPTION
Monkey patches the `run()` method to use `format_no_backlight` when /sys/class/backlight/ is empty.
