### PR TITLE
gpu_temp: setting "display_if" default value fixed

### DIFF
--- a/i3pystatus/gpu_temp.py
+++ b/i3pystatus/gpu_temp.py
@@ -24,7 +24,7 @@ class GPUTemperature(IntervalModule):
     color = "#FFFFFF"
     alert_temp = 90
     alert_color = "#FF0000"
-    display_if = True
+    display_if = 'True'
 
     def run(self):
         temp = gpu.query_nvidia_smi().temp


### PR DESCRIPTION
gpu_temp setting "display_if" (introduced in https://github.com/enkore/i3pystatus/pull/382) default value expected to be string (like in https://github.com/enkore/i3pystatus/pull/383)

Error message:
```
GPUTemperature: TypeError: eval() arg 1 must be a string, bytes or code object
```