### PR TITLE
Made updates method return types consistent and fixed bug in yaourt backend

### DIFF
--- a/i3pystatus/updates/aptget.py
+++ b/i3pystatus/updates/aptget.py
@@ -23,9 +23,9 @@ class AptGet(Backend):
         command = "apt-get upgrade -s -o Dir::State::Lists=" + cache_dir
         apt = run_through_shell(command.split())
 
-        out = apt.out.splitlines()
-        out = [line[5:] for line in out if line.startswith("Inst ")]
-        return len(out), out
+        out = apt.out.splitlines(True)
+        out = "".join([line[5:] for line in out if line.startswith("Inst ")])
+        return out.count("\n"), out
 
 Backend = AptGet
 

--- a/i3pystatus/updates/yaourt.py
+++ b/i3pystatus/updates/yaourt.py
@@ -14,8 +14,7 @@ class Yaourt(Backend):
         status.register("updates", backends = \
 [pacman.Pacman(), yaourt.Yaourt()])
 
-    If you want to count both pacman and aur packages with this module you can
-    set the variable count_only_aur = False like this:
+    To count both pacman and aur packages, pass False in the constructor:
 
     .. code-block:: python
 
@@ -32,7 +31,8 @@ class Yaourt(Backend):
         checkupdates = run_through_shell(command)
         out = checkupdates.out
         if(self.aur_only):
-            out = [line for line in out if line.startswith("aur")]
+            out = "".join([line for line in out.splitlines(True)
+                           if line.startswith("aur")])
         return out.count("\n"), out
 
 Backend = Yaourt


### PR DESCRIPTION
Changed the return types of aptget and yaourt to (int, string) from (int, list) to ensure consistency across all update backends and fixing the desktop notification for available updates, fixing #504.
Also fixed the bug in the yaourt backend that broke the `self.aur_only==True` case (see #505),
