### PR TITLE
Added packagekit backend for update notifications

### DIFF
--- a/i3pystatus/updates/packagekit.py
+++ b/i3pystatus/updates/packagekit.py
@@ -1,0 +1,31 @@
+import os
+
+from i3pystatus.core.command import run_through_shell
+from i3pystatus.updates import Backend
+
+
+class PackageKit(Backend):
+    """
+    Gets update count for distributions using PackageKit.
+
+    At the moment, it works with english localization, only.
+    """
+
+    @property
+    def updates(self):
+        command = "pkcon get-updates -p"
+        pk = run_through_shell(command.split())
+
+        out = pk.out.splitlines(True)
+        resultStrings = ("Security", "Bug fix", "Enhancement")
+        out = "".join([line for line in out[out.index("Results:\n") + 1:]
+                       if line.startswith(resultStrings)])
+        return out.count("\n"), out
+
+Backend = PackageKit
+
+if __name__ == "__main__":
+    """
+    Call this module directly; Print the update count and notification body.
+    """
+    print("Updates: {}\n\n{}".format(*Backend().updates))


### PR DESCRIPTION
This adds packagekit to the available update backends. As packagekit is used or at least can be used in many different Linux distributions (Standard in e.g. Fedora and OpenSUSE), this could be handy.