### PR TITLE
Allow empty stdout on shell module

### DIFF
--- a/i3pystatus/shell.py
+++ b/i3pystatus/shell.py
@@ -1,6 +1,5 @@
 from i3pystatus import IntervalModule
 from i3pystatus.core.command import run_through_shell
-import logging
 
 
 class Shell(IntervalModule):
@@ -14,9 +13,11 @@ class Shell(IntervalModule):
 
     color = "#FFFFFF"
     error_color = "#FF0000"
+    ignore_emtpy_stdout = False
 
     settings = (
         ("command", "command to be executed"),
+        ("ignore_emtpy_stdout", "Let the block be empty"),
         ("color", "standard color"),
         ("error_color", "color to use when non zero exit code is returned"),
         "format"
@@ -36,7 +37,11 @@ class Shell(IntervalModule):
         elif stderr:
             out = stderr
 
+        full_text = self.format.format(output=out).strip()
+        if not full_text and not self.ignore_emtpy_stdout:
+            full_text = "Command `%s` returned %d" % (self.command, retvalue)
+
         self.output = {
-            "full_text": self.format.format(output=out) if out else "Command `%s` returned %d" % (self.command, retvalue),
+            "full_text": full_text,
             "color": self.color if retvalue == 0 else self.error_color
         }


### PR DESCRIPTION
I have some `shell` scripts that does not have output for some cases, and the default output for the `shell` module is kinda useless for end results in my opinion.

I've modified the shell module with a new argument to allow having empty output supressing the "Command X returned status code Y" text, defaults to `False` to don't mess up actual configurations for people.