### PR TITLE
Forced Sphinx version < 1.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pytest>=2.5
-sphinx>=1.1
+sphinx>=1.1,<1.5
 colour>=0.0.5
 mock>=1.0
 pycodestyle>=1.5.7


### PR DESCRIPTION
Sphinx 1.5 dropped support for Python 3.3 which is the used in the travis file for CI, so all PR are failing. ([URL](https://github.com/sphinx-doc/sphinx/blob/master/CHANGES#L127))