### PR TITLE
Add mpd_command method

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -181,7 +181,7 @@ cleartext to the server.)"),
         try:
             self._mpd_command(self.s, "play"
                               if self._mpd_command(self.s, "status")["state"]
-                              in ["pause", "stop"] else "pause")
+                              in ["pause", "stop"] else "pause 1")
         except Exception as e:
             pass
 

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -36,6 +36,21 @@ Emulates ``mpc toggle``.
 next``.
     * ``previous_song`` — Goes to previous track in the playlist. Emulates \
 ``mpc prev``.
+    * ``mpd_command`` — Send a command directly to MPD's socket. The command \
+is the second element of the list. Documentation for available commands can \
+be found at https://www.musicpd.org/doc/protocol/command_reference.html
+
+    Example module registration with callbacks:
+
+    ::
+
+        status.register("mpd",
+            on_leftclick="switch_playpause",
+            on_rightclick=["mpd_command", "stop"],
+            on_middleclick=["mpd_command", "shuffle"],
+            on_upscroll=["mpd_command", "seekcur -10"],
+            on_downscroll=["mpd_command", "seekcur +10"])
+
     """
 
     interval = 1
@@ -185,5 +200,11 @@ cleartext to the server.)"),
     def previous_song(self):
         try:
             self._mpd_command(self.s, "previous")
+        except Exception as e:
+            pass
+
+    def mpd_command(self, command):
+        try:
+            self._mpd_command(self.s, command)
         except Exception as e:
             pass

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -51,6 +51,9 @@ be found at https://www.musicpd.org/doc/protocol/command_reference.html
             on_upscroll=["mpd_command", "seekcur -10"],
             on_downscroll=["mpd_command", "seekcur +10"])
 
+    Note that ``next_song`` and ``previous_song``, and their ``mpd_command`` \
+equivalents, are ignored while mpd is stopped.
+
     """
 
     interval = 1


### PR DESCRIPTION
This adds a method to talk directly to mpd using any of its own methods:
https://www.musicpd.org/doc/protocol/command_reference.html

There's no reason (other than backward compatibility) to keep the `stop`, `next_song`, and `previous_song` methods because these things can be done with `[mpd_command, "stop"]`, `[mpd_command, "previous"]`, and `[mpd_command, "next"]`.

The easiest way to experiment with the socket interface is with netcat; e.g. `nc localhost 6600`.