### PR TITLE
Add DBus callbacks to now_playing

### DIFF
--- a/i3pystatus/now_playing.py
+++ b/i3pystatus/now_playing.py
@@ -33,10 +33,13 @@ track.
     .. rubric:: Available formatters (uses :ref:`formatp`)
 
     * `{title}` — (the title of the current song)
-    * `{album}` — (the album of the current song, can be an empty string (e.g. for online streams))
+    * `{album}` — (the album of the current song, can be an empty string \
+(e.g. for online streams))
     * `{artist}` — (can be empty, too)
-    * `{filename}` — (file name with out extension and path; empty unless title is empty)
-    * `{song_elapsed}` — (position in the currently playing song, uses :ref:`TimeWrapper`, default is `%m:%S`)
+    * `{filename}` — (file name with out extension and path; empty unless \
+title is empty)
+    * `{song_elapsed}` — (position in the currently playing song, uses \
+:ref:`TimeWrapper`, default is `%m:%S`)
     * `{song_length}` — (length of the current song, same as song_elapsed)
     * `{status}` — (play, pause, stop mapped through the `status` dictionary)
     * `{volume}` — (volume)
@@ -146,22 +149,28 @@ https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
             currentsong = get_prop("Metadata")
 
             fdict = {
-                "status": self.status[self.statusmap[get_prop("PlaybackStatus")]],
-                "len": 0,  # TODO: Use optional(!) TrackList interface for this to gain 100 % mpd<->now_playing compat
+                "status": self.status[self.statusmap[
+                    get_prop("PlaybackStatus")]],
+                # TODO: Use optional(!) TrackList interface for this to
+                # gain 100 % mpd<->now_playing compat
+                "len": 0,
                 "pos": 0,
                 "volume": int(get_prop("Volume", 0) * 100),
 
                 "title": currentsong.get("xesam:title", ""),
                 "album": currentsong.get("xesam:album", ""),
                 "artist": ", ".join(currentsong.get("xesam:artist", "")),
-                "song_length": TimeWrapper((currentsong.get("mpris:length") or 0) / 1000 ** 2),
-                "song_elapsed": TimeWrapper((get_prop("Position") or 0) / 1000 ** 2),
+                "oong_length": TimeWrapper((currentsong.get("mpris:length") or
+                                            0) / 1000 ** 2),
+                "song_elapsed": TimeWrapper((get_prop("Position") or 0) /
+                                            1000 ** 2),
                 "filename": "",
             }
 
             if not fdict["title"]:
                 fdict["filename"] = '.'.join(
-                    basename((currentsong.get("xesam:url") or "")).split('.')[:-1])
+                    basename((currentsong.get("xesam:url") or "")).
+                    split('.')[:-1])
 
             self.data = fdict
             self.output = {

--- a/i3pystatus/now_playing.py
+++ b/i3pystatus/now_playing.py
@@ -1,5 +1,3 @@
-
-import functools
 from os.path import basename
 
 import dbus

--- a/i3pystatus/now_playing.py
+++ b/i3pystatus/now_playing.py
@@ -23,11 +23,14 @@ class NoPlayerException(Exception):
 
 class NowPlaying(IntervalModule):
     """
-    Shows currently playing track information, supports most media players
+    Shows currently playing track information. Supports media players that \
+conform to the Media Player Remote Interfacing Specification.
 
-    * Requires python-dbus available from every distros' package manager.
+    * Requires ``python-dbus`` from your distro package manager, or \
+``dbus-python`` from PyPI.
 
-    Left click on the module play/pauses, right click goes to the next track.
+    Left click on the module to play/pause, and right click to go to the next \
+track.
 
     .. rubric:: Available formatters (uses :ref:`formatp`)
 


### PR DESCRIPTION
Similar to #513, you can manipulate the MPRIS Player interface with the `player_command` and `player_prop` callbacks.
https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html

And like 513, this makes the `playpause` and `next_song` callbacks redundant. They can easily be removed.

Unlike socket connections, experimenting with dbus from the shell is not so straightforward, but you can do a lot with `busctl`.

Also, I propose renaming this module to something like `mpris`.