### PR TITLE
core: require internet is now updating each 5 seconds

### DIFF
--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -386,11 +386,15 @@ class internet:
     @classmethod
     def __bool__(cls):
         current_time = time.time()
-        with cls.lock:
-            if current_time - cls.last_time >= cls.update_delay_in_seconds:
+        if current_time - cls.last_time >= cls.update_delay_in_seconds:
+            with cls.lock:
                 cls.last_time = current_time
                 cls.last_result = cls._is_internet_available()
         return cls.last_result
+
+
+# init right away the value to avoid concurrencies problems at startup
+internet.last_result = internet._is_internet_available()
 
 
 def make_graph(values, lower_limit=0.0, upper_limit=100.0, style="blocks"):

--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -4,6 +4,7 @@ import inspect
 import re
 import socket
 import string
+import threading
 import time
 from threading import Timer, RLock
 
@@ -371,6 +372,7 @@ class internet:
     address = ("google-public-dns-a.google.com", 53)
     last_time = 0.0
     last_result = False
+    lock = threading.Lock()
     update_delay_in_seconds = 5
 
     @classmethod
@@ -384,14 +386,11 @@ class internet:
     @classmethod
     def __bool__(cls):
         current_time = time.time()
-        if current_time - cls.last_time >= cls.update_delay_in_seconds:
-            cls.last_time = current_time
-            cls.last_result = cls._is_internet_available()
+        with cls.lock:
+            if current_time - cls.last_time >= cls.update_delay_in_seconds:
+                cls.last_time = current_time
+                cls.last_result = cls._is_internet_available()
         return cls.last_result
-
-
-# init right away the value to avoid concurrencies problems at startup
-internet.last_result = internet._is_internet_available()
 
 
 def make_graph(values, lower_limit=0.0, upper_limit=100.0, style="blocks"):


### PR DESCRIPTION
Hi,

When I updated my PR #521 I noticed that `require(internet)` is not working as expected, and is only runned once for each module (because of the usage of __new__)...
I think that `require(internet)` should update his status globally at a fixed interval (interval that I have set to 5 seconds).
This PR fix that.

Regards,

##
Mathis 'hasB4K' Felardos