### PR TITLE
Corrected output of pomodoro module.

### DIFF
--- a/i3pystatus/pomodoro.py
+++ b/i3pystatus/pomodoro.py
@@ -83,7 +83,7 @@ class Pomodoro(IntervalModule):
             color = self.color_running if self.state == RUNNING else self.color_break
             text = self.format.format(**sdict)
         else:
-            text = 'Start pomodoro',
+            text = 'Start pomodoro'
             color = self.color_stopped
 
         self.output = {


### PR DESCRIPTION
There was a stale comma left from a previous refactor, this caused the module
to return output as a tuple, which ended up in the json as an array.
This has the effect that modules after (left of) this module refuse to display
in i3bar.