### PR TITLE
Revert "Forcibly update xkblayout module internal state"

### DIFF
--- a/i3pystatus/xkblayout.py
+++ b/i3pystatus/xkblayout.py
@@ -72,14 +72,7 @@ class Xkblayout(IntervalModule):
     def change_layout(self, increment=1):
         self._xkb.group_num += increment
 
-    def update_state(self):
-        """Update internal state if keyboard layout changed externally"""
-        self._xkb.close_display()
-        self._xkb.open_display()
-
     def run(self):
-        self.update_state()
-
         cdict = {
             "num": self._xkb.group_num,
             "name": self._xkb.group_name,


### PR DESCRIPTION
Sorry, bad idea to open PR without more testing.

Now I get Xkblayout: X11Error: Cannon open display ".0". after i3pystatus run for some time, probably because this PR is doing so many requests to X11 that X11 starts to block requests.

And I still can't change layouts after changing the layout externally, it used to work without the xkbgroup dependency.

Going to open another issue, maybe @hcpl there is a better idea on how to fix those bugs.