### PR TITLE
taskwarrior: Add `project` formatter for next task project

### DIFF
--- a/i3pystatus/taskwarrior.py
+++ b/i3pystatus/taskwarrior.py
@@ -13,6 +13,7 @@ class Taskwarrior(IntervalModule):
     * `{ready}`   — contains number of tasks returned by ready_filter
     * `{urgent}`  — contains number of tasks returned by urgent_filter
     * `{next}`    — contains the description of next task
+    * `{project}` — contains the projects the next task belongs to
     """
 
     format = 'Task: {next}'
@@ -79,6 +80,7 @@ class Taskwarrior(IntervalModule):
 
         if self.next_task is not None:
             format_values['next'] = self.next_task['description']
+            format_values['project'] = self.next_task['project']
 
         self.output = {
             'full_text': self.format.format(**format_values),


### PR DESCRIPTION
It's useful to be able to see what project the next task belongs to.

I thought about some other potential formatters too like due date or tags, but couldn't think of a sensible way to parse that data (e.g. pretty printing the number of days to a due date) so I've only added the project formatter. As I start to use this plugin more I might consider adding those other formatters, if the need arises.