### PR TITLE
Rename module: now_playing to mpris.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -453,7 +453,7 @@ recieved/sent part is changing color depending on the amount of traffic.
             )
 
 Or you can use pango to customize the color of ``status`` setting in
-:py:mod:`.now_playing` and :py:mod:`.mpd` modules.
+:py:mod:`.mpris` and :py:mod:`.mpd` modules.
 
     .. code:: python
 

--- a/docs/i3pystatus.rst
+++ b/docs/i3pystatus.rst
@@ -11,7 +11,7 @@ Module reference
 :Audio: `alsa`_ - `pulseaudio`_
 :Hardware: `backlight`_ - `battery`_ - `temp`_
 :Network: `net_speed`_ - `network`_ - `online`_ - `openstack_vms`_ - `openvpn`_
-:Music: `cmus`_ - `moc`_ - `mpd`_ - `now_playing`_ - `pianobar`_ - `spotify`_
+:Music: `cmus`_ - `moc`_ - `mpd`_ - `mpris`_ - `pianobar`_ - `spotify`_
 :Websites: `bitcoin`_ - `dota2wins`_ - `github`_ - `modsde`_ - `parcel`_ - `reddit`_ - `weather`_ -
            `whosonlocation`_
 :Other: `anybar`_ - `mail`_ - `pomodoro`_ - `pyload`_ - `text`_ - `updates`_

--- a/i3pystatus/mpris.py
+++ b/i3pystatus/mpris.py
@@ -19,7 +19,7 @@ class NoPlayerException(Exception):
     pass
 
 
-class NowPlaying(IntervalModule):
+class Mpris(IntervalModule):
     """
     Shows currently playing track information. Supports media players that \
 conform to the Media Player Remote Interfacing Specification.
@@ -62,7 +62,7 @@ https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
 
     ::
 
-        status.register("now_playing",
+        status.register("mpris",
             on_leftclick=["player_command", "PlayPause"],
             on_rightclick=["player_command", "Stop"],
             on_middleclick=["player_prop", "Shuffle", True],
@@ -152,7 +152,7 @@ https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
                 "status": self.status[self.statusmap[
                     get_prop("PlaybackStatus")]],
                 # TODO: Use optional(!) TrackList interface for this to
-                # gain 100 % mpd<->now_playing compat
+                # gain 100 % mpd<->mpris compat
                 "len": 0,
                 "pos": 0,
                 "volume": int(get_prop("Volume", 0) * 100),

--- a/i3pystatus/spotify.py
+++ b/i3pystatus/spotify.py
@@ -1,8 +1,8 @@
-from i3pystatus.now_playing import NowPlaying
+from i3pystatus.mpris import Mpris
 
 
-class Spotify(NowPlaying):
+class Spotify(Mpris):
     """
-    Get Spotify info using dbus interface. Based on `now_playing`_ module.
+    Get Spotify info using dbus interface. Based on `mpris`_ module.
     """
     player_name = "spotify"


### PR DESCRIPTION
The name is more appropriate, but this will break existing configs.