### PR TITLE
Wildcard interface names

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -327,6 +327,12 @@ class Network(IntervalModule, ColorRangeModule):
         else:
             get_wifi_info = False
 
+        # wildcard interface names
+        for s in netifaces.interfaces():
+            if self.interface in s:
+                self.interface = s
+                break
+
         self.network_info = NetworkInfo(self.interface, self.ignore_interfaces, self.detached_down, self.unknown_up,
                                         get_wifi_info)
 


### PR DESCRIPTION
allows you to use wildcards such as `wlp` or `enp` in the config. useful if you use the same config on multiple hosts to get the first (wireless) device. kinda like [__first__](https://i3wm.org/i3status/manpage.html#_wireless) does