### PR TITLE
Fix uptime alert colors not being used with certain format strings

### DIFF
--- a/i3pystatus/uptime.py
+++ b/i3pystatus/uptime.py
@@ -34,6 +34,8 @@ class Uptime(IntervalModule):
         with open(self.file, "r") as f:
             seconds = int(float(f.read().split()[0]))
 
+        raw_seconds = seconds
+
         days = seconds // (60 * 60 * 24)
         hours = seconds // (60 * 60)
         minutes = seconds // 60
@@ -56,7 +58,7 @@ class Uptime(IntervalModule):
         }
         self.data = fdict
         if self.alert:
-            if seconds > self.seconds_alert:
+            if raw_seconds > self.seconds_alert:
                 self.color = self.color_alert
         self.output = {
             "full_text": formatp(self.format, **fdict),


### PR DESCRIPTION
I noticed a small bug in the uptime module regarding the alerts, so I figured I'd send a small pull request.

The uptime module checks `seconds_alert` against `seconds` to determine whether the uptime is high enough to use the alert color.

However, earlier in the code, if `{days}`, `{hours}`, or `{mins}` is in the format string, `seconds` is set to the remaining seconds excluding the days, hours, or minutes.

So, for example, if you have `{mins}` in the format string, it will do `seconds = seconds % 60`, so when later compared against `seconds_alert`, `seconds` will be too low to trigger alert coloring unless you have `seconds_alert` set lower than 60.

This fixes that by just saving the "raw" seconds that were originally read, and comparing `seconds_alert` against that instead.