### PR TITLE
I'm an idiot and put my API key in the Weather Underground example

### DIFF
--- a/i3pystatus/weather/wunderground.py
+++ b/i3pystatus/weather/wunderground.py
@@ -68,7 +68,7 @@ class Wunderground(WeatherBackend):
             colorize=True,
             hints={'markup': 'pango'},
             backend=wunderground.Wunderground(
-                api_key='dbafe887d56ba4ad',
+                api_key='api_key_goes_here',
                 location_code='pws:MAT645',
                 units='imperial',
                 forecast=True,


### PR DESCRIPTION
Just got a usage alert when my laptop wasn't even on.

n00b mistake! I've disabled the API key, and this removes it from the
example in the documentation.