### PR TITLE
Fix weathercom module

### DIFF
--- a/i3pystatus/weather/weathercom.py
+++ b/i3pystatus/weather/weathercom.py
@@ -43,7 +43,7 @@ class WeathercomHTMLParser(HTMLParser):
     def load_json(self, json_input):
         self.logger.debug('Loading the following data as JSON: %s', json_input)
         try:
-            return json.loads(json_string)
+            return json.loads(json_input)
         except json.decoder.JSONDecodeError as exc:
             self.logger.debug('Error loading JSON: %s', exc)
             self.logger.debug('String that failed to load: %s', json_input)


### PR DESCRIPTION
The weathcom module was broken due to referencing a variable that did
not exist.  It appears this was a typo or copy/paste error.  Either way,
this patch fixes that error and the weathcom module works again!