### PR TITLE
Calculate battery percentage from energy instead of average of batteries

### DIFF
--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -78,6 +78,9 @@ class BatteryCharge(Battery):
     def wh_remaining(self):
         return self.battery_info['CHARGE_NOW'] * self.battery_info['VOLTAGE_NOW']
 
+    def wh_total(self):
+        return self.battery_info['CHARGE_FULL'] * self.battery_info['VOLTAGE_NOW']
+
     def wh_depleted(self):
         return (self.battery_info['CHARGE_FULL'] - self.battery_info['CHARGE_NOW']) * self.battery_info['VOLTAGE_NOW']
 
@@ -102,6 +105,9 @@ class BatteryEnergy(Battery):
 
     def wh_remaining(self):
         return self.battery_info['ENERGY_NOW']
+
+    def wh_total(self):
+        return self.battery_info['ENERGY_FULL']
 
     def wh_depleted(self):
         return self.battery_info['ENERGY_FULL'] - self.battery_info['ENERGY_NOW']
@@ -219,22 +225,9 @@ class BatteryChecker(IntervalModule):
     path = None
     paths = []
 
-    def _old_percentage(self, batteries, design=False):
-        total = 0
-        for battery in batteries:
-            total += battery.percentage(design)
-        return total / len(batteries)
-
     def percentage(self, batteries, design=False):
-        types = [type(battery) for battery in batteries]
-        if len(set(types)) == 1 and types[0] == BatteryEnergy:
-            total_now = [battery.battery_info["ENERGY_NOW"] for battery in batteries]
-            total_full = [battery.battery_info["ENERGY_FULL"] for battery in batteries]
-        if len(set(types)) == 1 and types[0] == BatteryCharge:
-            total_now = [battery.battery_info["CHARGE_NOW"] for battery in batteries]
-            total_full = [battery.battery_info["CHARGE_FULL"] for battery in batteries]
-        else:
-            return self._old_percentage(batteries, design)
+        total_now = [battery.wh_remaining() for battery in batteries]
+        total_full = [battery.wh_total() for battery in batteries]
         return sum(total_now) / sum(total_full) * 100
 
     def consumption(self, batteries):

--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -220,10 +220,9 @@ class BatteryChecker(IntervalModule):
     paths = []
 
     def percentage(self, batteries, design=False):
-        total = 0
-        for battery in batteries:
-            total += battery.percentage(design)
-        return total / len(batteries)
+        total_now = [battery.battery_info["ENERGY_NOW"] for battery in batteries]
+        total_full = [battery.battery_info["ENERGY_FULL"] for battery in batteries]
+        return sum(total_now) / sum(total_full) * 100
 
     def consumption(self, batteries):
         consumption = 0

--- a/i3pystatus/battery.py
+++ b/i3pystatus/battery.py
@@ -219,9 +219,22 @@ class BatteryChecker(IntervalModule):
     path = None
     paths = []
 
+    def _old_percentage(self, batteries, design=False):
+        total = 0
+        for battery in batteries:
+            total += battery.percentage(design)
+        return total / len(batteries)
+
     def percentage(self, batteries, design=False):
-        total_now = [battery.battery_info["ENERGY_NOW"] for battery in batteries]
-        total_full = [battery.battery_info["ENERGY_FULL"] for battery in batteries]
+        types = [type(battery) for battery in batteries]
+        if len(set(types)) == 1 and types[0] == BatteryEnergy:
+            total_now = [battery.battery_info["ENERGY_NOW"] for battery in batteries]
+            total_full = [battery.battery_info["ENERGY_FULL"] for battery in batteries]
+        if len(set(types)) == 1 and types[0] == BatteryCharge:
+            total_now = [battery.battery_info["CHARGE_NOW"] for battery in batteries]
+            total_full = [battery.battery_info["CHARGE_FULL"] for battery in batteries]
+        else:
+            return self._old_percentage(batteries, design)
         return sum(total_now) / sum(total_full) * 100
 
     def consumption(self, batteries):


### PR DESCRIPTION
Average only works if all batteries have the same max energy level. If setups with different sizes the smaller ones influence the percentage overproportianly strong