### PR TITLE
docs: highlight module name to use with register

### DIFF
--- a/docs/_static/i3pystatus.css
+++ b/docs/_static/i3pystatus.css
@@ -1,0 +1,20 @@
+
+#module-reference dl.class dt .property,
+#module-reference dl.class dt .descclassname,
+#module-reference dl.class dt .descname
+{
+    display: none;
+}
+
+#module-reference dl.class dd {
+    margin-top: -1.5em;
+}
+
+#module-reference dl.class .modheader {
+    margin-left: -2em;
+    margin-bottom: .5em;
+}
+
+#module-reference dl.class .modname {
+    font-weight: bold;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ html_theme = "haiku"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -344,3 +344,6 @@ epub_copyright = '2013, Author'
 
 # If false, no index is generated.
 #epub_use_index = True
+
+def setup(app):
+    app.add_stylesheet('i3pystatus.css')

--- a/docs/module_docs.py
+++ b/docs/module_docs.py
@@ -80,6 +80,27 @@ def process_docstring(app, what, name, obj, options, lines):
     if is_module(obj) and obj.settings:
         fail_on_missing_dependency_hints(obj, lines)
 
+        if issubclass(obj, i3pystatus.core.modules.Module):
+            mod = obj.__module__
+            if mod.startswith("i3pystatus."):
+                mod = mod[len("i3pystatus."):]
+            lines[0:0] = [
+                ".. raw:: html",
+                "",
+                "    <div class='modheader'>" +
+                "Module name: <code class='modname descclassname'>" + mod + "</code> " +
+                "(class <code class='descclassname'>" + name + "</code>)" +
+                "</div>",
+                "",
+            ]
+        else:
+            lines[0:0] = [
+                ".. raw:: html",
+                "",
+                "    <div class='modheader'>class <code class='descclassname'>" + name + "</code></div>",
+                "",
+            ]
+
         lines.append(".. rubric:: Settings")
         lines.append("")
 


### PR DESCRIPTION
~#570

Instead of

> _class_ i3pystatus.abc_radio.ABCRadio

gives

> Module name: **abc_radio** (class i3pystatus.abc_radio.ABCRadio)

