### PR TITLE
core/desktop: don't crash if gi exists but is empty (#314)

### DIFF
--- a/i3pystatus/core/desktop.py
+++ b/i3pystatus/core/desktop.py
@@ -57,7 +57,7 @@ try:
 
     gi.require_version('Notify', '0.7')
     from gi.repository import Notify
-except (ImportError, ValueError):
+except (ImportError, ValueError, AttributeError):
     pass
 else:
     if not Notify.init("i3pystatus"):


### PR DESCRIPTION
Many packages install something into `gi/overrides`. If the `gobject`
package itself is not installed, the import of `gi` succeeds but
`require_version` is not contained within, resulting in an `AttributeError`.

---

As requested in https://github.com/enkore/i3pystatus/issues/314. Just ran into this myself. (In my case the package installing something into `gi/overrides` was https://github.com/storaged-project/libblockdev.)

Alternatively I suppose the import of `Notify` could be moved above the `require_version` call, which would cause an `ImportError` at that point. But the `require_version` call looks like it might do some magic (maybe it's required for the import to work properly?), so I'm not confident in making that change offhand.