### PR TITLE
Fix breakage introduced in #595

### DIFF
--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -370,7 +370,7 @@ class internet:
         :py:func:`require`
 
     """
-    address = ("8.8.8.8", 53)
+    address = ("google-public-dns-a.google.com", 53)
 
     check_frequency = 1
     last_checked = time.perf_counter() - check_frequency


### PR DESCRIPTION
PR #595 assumed a very specific network setup, and breaks the `internet` predicate on other setups. 

Noticeably, it broke on IPv6-only networks (including those using NAT64, and other modern transition mechanisms).