### PR TITLE
Add module "keep_alive" feature.

### DIFF
--- a/i3pystatus/abc_radio.py
+++ b/i3pystatus/abc_radio.py
@@ -57,6 +57,8 @@ class ABCRadio(IntervalModule):
     # Destroy the player after this many seconds of inactivity
     PLAYER_LIFETIME = 5
 
+    # Do not suspend the player when i3bar is hidden.
+    keep_alive = True
     show_info = {}
     player = None
     station_info = None

--- a/i3pystatus/core/io.py
+++ b/i3pystatus/core/io.py
@@ -1,9 +1,11 @@
 import json
 import signal
 import sys
+
 from contextlib import contextmanager
 from threading import Condition
 from threading import Thread
+from i3pystatus.core.modules import IntervalModule
 
 
 class IOHandler:
@@ -54,7 +56,12 @@ class StandaloneIO(IOHandler):
 
     n = -1
     proto = [
-        {"version": 1, "click_events": True}, "[", "[]", ",[]",
+        {
+            "version": 1,
+            "click_events": True,
+            "stop_signal": signal.SIGUSR2,
+            "cont_signal": signal.SIGUSR2
+        }, "[", "[]", ",[]",
     ]
 
     def __init__(self, click_events, modules, interval=1):
@@ -72,7 +79,10 @@ class StandaloneIO(IOHandler):
 
         self.refresh_cond = Condition()
         self.treshold_interval = 20.0
+
+        self.stopped = False
         signal.signal(signal.SIGUSR1, self.refresh_signal_handler)
+        signal.signal(signal.SIGUSR2, self.suspend_signal_handler)
 
     def read(self):
         self.compute_treshold_interval()
@@ -141,6 +151,26 @@ class StandaloneIO(IOHandler):
                 module.run()
 
         self.async_refresh()
+
+    def suspend_signal_handler(self, signo, frame):
+        """
+        By default, i3bar sends SIGSTOP to all children when it is not visible (for example, the screen
+        sleeps or you enter full screen mode). This stops the i3pystatus process and all threads within it.
+        For some modules, this is not desirable. Thankfully, the i3bar protocol supports setting the "stop_signal"
+        and "cont_signal" key/value pairs in the header to allow sending a custom signal when these events occur.
+
+        Here we use SIGUSR2 for both "stop_signal" and "cont_signal" and maintain a toggle to determine whether
+        we have just been stopped or continued. When we have been stopped, notify the IntervalModule managers
+        that they should suspend any module that does not set the keep_alive flag to a truthy value, and when we
+        have been continued, notify the IntervalModule managers that they can resume execution of all modules.
+        """
+        if signo != signal.SIGUSR2:
+            return
+        self.stopped = not self.stopped
+        if self.stopped:
+            [m.suspend() for m in IntervalModule.managers.values()]
+        else:
+            [m.resume() for m in IntervalModule.managers.values()]
 
 
 class JSONIO:

--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -316,6 +316,8 @@ class Network(IntervalModule, ColorRangeModule):
         ("detect_active", "Attempt to detect the active interface"),
     )
 
+    # Continue processing statistics when i3bar is hidden.
+    keep_alive = True
     interval = 1
     interface = 'eth0'
 


### PR DESCRIPTION
By default, i3bar sends SIGSTOP to all children when it is not visible (for example, the screen
sleeps or you enter full screen mode), stopping the i3pystatus process and all threads within it.
For some modules, this is not desirable. This commit makes it possible for modules to define the
"keep_alive" flag to indicate that they would like to continue executing regardless of the state of
i3bar.