### PR TITLE
New source of cpu information

### DIFF
--- a/i3pystatus/cpu_freq.py
+++ b/i3pystatus/cpu_freq.py
@@ -33,18 +33,18 @@ class CpuFreq(IntervalModule):
             with open('/sys/devices/system/cpu/online') as f:
                 line = f.readline()
                 cpus_online = [int(cpu) for cpu in line.split(',') if cpu.find('-') < 0]
-                cpus_online_range = [cpu_range for cpu_range in line.split('-') if cpu_range.find('-') > 0 ]
+                cpus_online_range = [cpu_range for cpu_range in line.split('-') if cpu_range.find('-') > 0]
 
             for cpu_range in cpus_online_range:
-                cpus_online += [cpu for cpu in range(int(cpu_range[0]), int(cpu_range[1])+1)]
+                cpus_online += [cpu for cpu in range(int(cpu_range[0]), int(cpu_range[1]) + 1)]
 
-            mhz_values = [0.0 for cpu in range(max(cpus_online)+1)]
-            ghz_values = [0.0 for cpu in range(max(cpus_online)+1)]
+            mhz_values = [0.0 for cpu in range(max(cpus_online) + 1)]
+            ghz_values = [0.0 for cpu in range(max(cpus_online) + 1)]
             for cpu in cpus_online:
                 with open('/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq'.format(cpu)) as f:
                     line = f.readline()
-                    mhz_values[cpu]=float(line.rstrip()) / 1000.0
-                    ghz_values[cpu]=float(line.rstrip()) / 1000000.0
+                    mhz_values[cpu] = float(line.rstrip()) / 1000.0
+                    ghz_values[cpu] = float(line.rstrip()) / 1000000.0
             cpus_offline = mhz_values.count(0.0)
         else:
             with open(self.file) as f:
@@ -55,8 +55,8 @@ class CpuFreq(IntervalModule):
         ghz = {"core{}g".format(key): "{0:1.2f}".format(value) for key, value in enumerate(ghz_values)}
         cdict = mhz.copy()
         cdict.update(ghz)
-        cdict['avg'] = "{0:4.3f}".format(sum(mhz_values) / (len(mhz_values)-cpus_offline))
-        cdict['avgg'] = "{0:1.2f}".format(sum(ghz_values) / (len(ghz_values)-cpus_offline),2)
+        cdict['avg'] = "{0:4.3f}".format(sum(mhz_values) / (len(mhz_values) - cpus_offline))
+        cdict['avgg'] = "{0:1.2f}".format(sum(ghz_values) / (len(ghz_values) - cpus_offline), 2)
         return cdict
 
     def run(self):

--- a/i3pystatus/cpu_freq.py
+++ b/i3pystatus/cpu_freq.py
@@ -33,10 +33,10 @@ class CpuFreq(IntervalModule):
             with open('/sys/devices/system/cpu/online') as f:
                 line = f.readline()
                 cpus_online = [int(cpu) for cpu in line.split(',') if cpu.find('-') < 0]
-                cpus_online_range = [cpu_range for cpu_range in line.split('-') if cpu_range.find('-') > 0]
+                cpus_online_range = [cpu_range for cpu_range in line.split(',') if cpu_range.find('-') > 0]
 
             for cpu_range in cpus_online_range:
-                cpus_online += [cpu for cpu in range(int(cpu_range[0]), int(cpu_range[1]) + 1)]
+                cpus_online += [cpu for cpu in range(int(cpu_range.split('-')[0]), int(cpu_range.split('-')[1]) + 1)]
 
             mhz_values = [0.0 for cpu in range(max(cpus_online) + 1)]
             ghz_values = [0.0 for cpu in range(max(cpus_online) + 1)]

--- a/i3pystatus/cpu_freq.py
+++ b/i3pystatus/cpu_freq.py
@@ -25,19 +25,38 @@ class CpuFreq(IntervalModule):
 
     def createvaluesdict(self):
         """
-        function processes the /proc/cpuinfo file
+        function processes the /proc/cpuinfo file, use file=/sys to use kernel >=4.13 location
         :return: dictionary used as the full-text output for the module
         """
-        with open(self.file) as f:
-            mhz_values = [float(line.split(':')[1]) for line in f if line.startswith('cpu MHz')]
-            ghz_values = [value / 1000.0 for value in mhz_values]
+        cpus_offline = 0
+        if self.file == '/sys':
+            with open('/sys/devices/system/cpu/online') as f:
+                line = f.readline()
+                cpus_online = [int(cpu) for cpu in line.split(',') if cpu.find('-') < 0]
+                cpus_online_range = [cpu_range for cpu_range in line.split('-') if cpu_range.find('-') > 0 ]
+
+            for cpu_range in cpus_online_range:
+                cpus_online += [cpu for cpu in range(int(cpu_range[0]), int(cpu_range[1])+1)]
+
+            mhz_values = [0.0 for cpu in range(max(cpus_online)+1)]
+            ghz_values = [0.0 for cpu in range(max(cpus_online)+1)]
+            for cpu in cpus_online:
+                with open('/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq'.format(cpu)) as f:
+                    line = f.readline()
+                    mhz_values[cpu]=float(line.rstrip()) / 1000.0
+                    ghz_values[cpu]=float(line.rstrip()) / 1000000.0
+            cpus_offline = mhz_values.count(0.0)
+        else:
+            with open(self.file) as f:
+                mhz_values = [float(line.split(':')[1]) for line in f if line.startswith('cpu MHz')]
+                ghz_values = [value / 1000.0 for value in mhz_values]
 
         mhz = {"core{}".format(key): "{0:4.3f}".format(value) for key, value in enumerate(mhz_values)}
         ghz = {"core{}g".format(key): "{0:1.2f}".format(value) for key, value in enumerate(ghz_values)}
         cdict = mhz.copy()
         cdict.update(ghz)
-        cdict['avg'] = "{0:4.3f}".format(sum(mhz_values) / len(mhz_values))
-        cdict['avgg'] = "{0:1.2f}".format(sum(ghz_values) / len(ghz_values), 2)
+        cdict['avg'] = "{0:4.3f}".format(sum(mhz_values) / (len(mhz_values)-cpus_offline))
+        cdict['avgg'] = "{0:1.2f}".format(sum(ghz_values) / (len(ghz_values)-cpus_offline),2)
         return cdict
 
     def run(self):


### PR DESCRIPTION
Hi, this PR adds the following : 

Starting with kernel 4.13 /proc/cpuinfo only shows the base clock frequency of the processor, not the current. 

https://bugzilla.kernel.org/show_bug.cgi?id=197009#c1

So this change extracts the current frequency from /sys/devices/system/cpu and considers also if the cpu's are online or offline . Using only the "file" parameter override with **/sys** value: 

`status.register("cpu_freq", format="{avgg} GHz", file='/sys', interval=1)`

