### PR TITLE
network: Fix missing wifi info when using format_active_up

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -353,8 +353,9 @@ class Network(IntervalModule, ColorRangeModule):
 
     def init(self):
         # Don't require importing basiciw unless using the functionality it offers.
-        if any(s in self.format_down or s in self.format_up for s in
-               ['essid', 'freq', 'quality', 'quality_bar']):
+        if any(s in self.format_down or s in self.format_up or
+               any(s in f for f in self.format_active_up.values())
+               for s in ['essid', 'freq', 'quality', 'quality_bar']):
             get_wifi_info = True
         else:
             get_wifi_info = False


### PR DESCRIPTION
This PR fixes a small bug that I found in the network module.

The relevant part of my config is:
```
status.register("network",
    detect_active=True,
    format_up="(?) {v4}",
    format_down="No Network",
    format_active_up={
        "wl*": "WIFI {essid} {quality:02.0f}% {v4}",
    })
```

What I expected to see: `WIFI MyCreativeSSID 42% 10.1.2.3`
What actually happens: `WIFI  00% 10.1.2.3`

The problem here is that the network module doesn't use basiciw if there are no wifi keywords in `format_up` or `format_down`.
My solution is to also look for wifi keywords in `format_active_up`.
