### PR TITLE
Change DesktopNotification arguments

### DIFF
--- a/i3pystatus/pomodoro.py
+++ b/i3pystatus/pomodoro.py
@@ -101,7 +101,7 @@ class Pomodoro(IntervalModule):
         self.time = None
 
     def _alarm(self, text):
-        notification = DesktopNotification('Alarm!', text)
+        notification = DesktopNotification(title='Alarm!', body=text)
         notification.display()
 
         subprocess.Popen(['aplay',


### PR DESCRIPTION
Change `DesktopNotification` arguments to named arguments because `DesktopNotification` constructor uses `**kwarg` and requires named arguments.