### PR TITLE
Fixes deprecated usage of Formatter.format.

### DIFF
--- a/i3pystatus/cpu_usage.py
+++ b/i3pystatus/cpu_usage.py
@@ -85,9 +85,8 @@ class CpuUsage(IntervalModule):
                 continue
 
             core = core.replace('usage_', '')
-            string = self.formatter.format(self.format_all,
-                                           core=core,
-                                           usage=usage)
+            string = self.formatter.vformat(self.format_all, (),
+                                            {'core': core, 'usage': usage})
             core_strings.append(string)
 
         core_strings = sorted(core_strings)


### PR DESCRIPTION
Formatter.format arguments are now positional-only (Python 3.7).

Check [here](https://docs.python.org/3/library/string.html#string.Formatter.format).
