### PR TITLE
temp.py: Fixed bug related to dynamic colors

### DIFF
--- a/i3pystatus/temp.py
+++ b/i3pystatus/temp.py
@@ -189,7 +189,10 @@ class Temperature(IntervalModule, ColorRangeModule):
             temp = float(f.read().strip()) / 1000
 
         if self.dynamic_color:
-            color = self.colors[int(self.percentage(int(temp), self.alert_temp))]
+            perc = int(self.percentage(int(temp), self.alert_temp))
+            if (perc > 99):
+                perc = 99
+            color = self.colors[perc]
         else:
             color = self.color if temp < self.alert_temp else self.alert_color
         return {


### PR DESCRIPTION
When a custom alert_temp was given, for any temperature value above `alert_temp`
the module generated an `IndexError: string index out of range` error.

The problem was that for any temperature greater than `alert_temp`, the percentage returned from `self.percentage` was above 99. So, I simply fixed the error setting a maximum value for the percentage to 99.