### PR TITLE
Deluge

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ MOCK_MODULES = [
     "requests.exceptions",
     "bs4",
     "dota2py",
+    'deluge-client',
     "novaclient",
     "speedtest",
     "pyzabbix",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ MOCK_MODULES = [
     "requests.exceptions",
     "bs4",
     "dota2py",
-    'deluge-client',
+    'deluge_client',
     "novaclient",
     "speedtest",
     "pyzabbix",

--- a/i3pystatus/core/util.py
+++ b/i3pystatus/core/util.py
@@ -136,6 +136,20 @@ def convert_position(pos, json):
     return pos
 
 
+def bytes_info_dict(in_bytes):
+    power = 2**10  # 2 ** 10 == 1024
+    n = 0
+    pow_dict = {0: '', 1: 'K', 2: 'M', 3: 'G', 4: 'T'}
+    out_bytes = int(in_bytes)
+    while out_bytes > power:
+        out_bytes /= power
+        n += 1
+    return {
+        'value': out_bytes,
+        'unit': '{prefix}B'.format(prefix=pow_dict[n])
+    }
+
+
 def flatten(l):
     """
     Flattens a hierarchy of nested lists into a single list containing all elements in order

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -1,116 +1,70 @@
-import requests
 import time
 
-from i3pystatus import IntervalModule
+from deluge_client import DelugeRPCClient
+
+from i3pystatus import IntervalModule, logger
 from i3pystatus.core.util import bytes_info_dict
 
 
 class Deluge(IntervalModule):
     """
     Deluge torrent module
-    You will need to enable the web ui in deluge.
-    Requires `requests`
+    Requires `deluge-client`
 
     .. rubric:: Formatters:
 
     * `{num_torrents}`       - number of torrents in deluge
     * `{free_space_bytes}`   - bytes free in path
-    * `{daemon_version}`     - current version of deluge running on the server
     * `{used_space_bytes}`   - bytes used in path
-    * `{net_sent_sec_bytes}` - bytes sent per second
-    * `{net_recv_sec_bytes}` - bytes received per second
-    * `{net_sent_bytes}`     - bytes sent total
-    * `{net_recv_bytes}`     - bytes received total
-
-    .. rubric:: Unlisted Formatters:
-
-    Deluge 2+ only:
-    due to the sheer number of options in libtorrent, if you enable collection of
-    libtorrent stats the keys are in the link below, just click 'session statistics'
-    from the table of contents (for compatibility reasons, replace the fullstop in
-    the name with an underscore, eg `net.recv_bytes` -> `net_recv_bytes`.
-    https://www.libtorrent.org/manual-ref.html#session-statistics
+    * `{upload_rate}` - bytes sent per second
+    * `{download_rate}` - bytes received per second
+    * `{total_uploaded}`     - bytes sent total
+    * `{total_downloaded}`     - bytes received total
 
     """
-    # TODO: convert this module to run off a python library rather then requests
-    #       i chose requests because at the time 2.0.0-b isnt supported by any
-    #       libraries.
 
     settings = (
-        ('format'),
+        'format',
         ('rounding', 'number of decimal places to round numbers too'),
         ('host', 'address of deluge server (default: 127.0.0.1)'),
         ('port', 'port of deluge server (default: 58846)'),
-        ('password', 'password to authenticate to deluge (default: deluge)'),
+        ('username', 'username to authenticate with deluge'),
+        ('password', 'password to authenticate to deluge'),
         ('path', 'override "download path" server-side when checking space used/free'),
-        ('libtorrent_stats', 'Deluge 2+ only. bool. set to True to pull all stats from libtorrent '
-                             '(may cause high memory usage on older machines)(default: False)',
-         )
     )
+    required = ('username', 'password')
 
     host = '127.0.0.1'
-    port = 8112
-    password = 'deluge'
+    port = 58846
     path = None
     libtorrent_stats = False
     rounding = 2
 
     format = '⛆{num_torrents} ✇{free_space_bytes}'
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-    }
-
     id = int(time.time())  # something random
 
     def init(self):
-        if any(s in self.format for s in ('net_sent_sec_bytes', 'net_recv_sec_bytes')):
-            self.libtorrent_stats = True
-
-        self.session = None
-        self.last_tick = None
-        self.last_session_statistics = None
+        self.client = DelugeRPCClient(self.host, self.port, self.username, self.password)
         self.data = {}
-        self.daemon_version = None
 
     def run(self):
-        if not self.check_session():
-            self.authenticate()
+        if not self.client.connected:
+            self.client.connect()
 
-        if not self.daemon_version:
-            self.daemon_version = self.detect_version()
-            format_values = {'daemon_version': self.daemon_version}
-        format_values = dict(num_torrents='', free_space='', daemon_version='', used_space='',
-                             net_recv_sec_bytes='', net_sent_sec_bytes='')
-
-        if self.libtorrent_stats:
-            format_values.update(self.get_session_statistics())
-
-            if self.daemon_version >= '2':
-                def calculate_bytes_per_sec(key):
-                    return (format_values[key] - self.last_session_statistics[key]) / (this_tick - self.last_tick)
-
-                this_tick = time.time()
-                if self.data is not None and self.last_session_statistics is not None:
-                    format_values['net_sent_sec_bytes'] = calculate_bytes_per_sec('net_sent_bytes')
-                    format_values['net_recv_sec_bytes'] = calculate_bytes_per_sec('net_recv_bytes')
-
-                self.last_tick = float(this_tick)
-                self.last_session_statistics = dict(format_values)
+        self.data = self.get_session_statistics()
 
         torrents = self.get_torrents_status()
         if torrents:
-            format_values['num_torrents'] = len(torrents)
+            self.data['num_torrents'] = len(torrents)
 
         if 'free_space_bytes' in self.format:
-            format_values['free_space_bytes'] = self.get_free_space(self.path)
+            self.data['free_space_bytes'] = self.get_free_space(self.path)
         if 'used_space_bytes' in self.format:
-            format_values['used_space_bytes'] = self.get_path_size(self.path)
+            self.data['used_space_bytes'] = self.get_path_size(self.path)
 
-        self.parse_values(format_values)
+        self.parse_values(self.data)
 
-        self.data.update(format_values)
         self.output = {
             'full_text': self.format.format(**self.data)
         }
@@ -118,16 +72,8 @@ class Deluge(IntervalModule):
     def parse_values(self, values):
         for k, v in values.items():
             if v:
-                if k.endswith('_bytes'):
+                if k in ['total_upload', 'total_download', 'download_rate', 'upload_rate'] or k.endswith('_bytes'):
                     values[k] = '{value:.{round}f}{unit}'.format(round=self.rounding, **bytes_info_dict(v))
-
-    def authenticate(self):
-        payload = self._gen_request('auth.login', [self.password])
-        return self._send_request(payload)
-
-    def check_session(self):
-        payload = self._gen_request('auth.check_session')
-        return self._send_request(payload)
 
     def get_path_size(self, path=None):
         """
@@ -135,8 +81,7 @@ class Deluge(IntervalModule):
         """
         if path is None:
             path = []
-        payload = self._gen_request('core.get_path_size', path)
-        return self._send_request(payload)
+        return self.client.call('core.get_path_size', path)
 
     def get_free_space(self, path=None):
         """
@@ -144,63 +89,24 @@ class Deluge(IntervalModule):
         """
         if path is None:
             path = []
-        payload = self._gen_request('core.get_free_space', path)
-        return self._send_request(payload)
+        return self.client.call('core.get_free_space', path)
 
     def get_torrents_status(self, torrent_id=None, keys=None):
         if torrent_id is None:
             torrent_id = []
         if keys is None:
             keys = []
-        payload = self._gen_request('core.get_torrents_status', [torrent_id, keys])
-        return self._send_request(payload)
-
-    def detect_version(self):
-        payload = self._gen_request('daemon.get_method_list')
-        response = self._send_request(payload)
-        if 'daemon.info' in response:
-            ver_meth = 'daemon.info'
-        else:
-            ver_meth = 'daemon.get_version'
-
-        payload = self._gen_request(ver_meth, [])
-        daemon_version = self._send_request(payload)
-        self.data['daemon_version'] = daemon_version
-        return daemon_version
+        return self.client.call('core.get_torrents_status', torrent_id, keys)
 
     def get_session_statistics(self):
-        keys = []
-        if self.data['daemon_version'] < '2':
-            keys = [['upload_rate', 'download_rate', 'total_upload', 'total_download']]
+        keys = ['upload_rate', 'download_rate', 'total_upload', 'total_download']
 
-        payload = self._gen_request('core.get_session_status', keys)
-        response = self._send_request(payload)
+        out = {}  # some of the values from deluge-client are bytes, the others are ints - we need to decode them
+        for k, v in self.client.call('core.get_session_status', keys).items():
+            k = k.decode('utf-8')  # keys aswell
+            if type(v) == bytes:
+                out[k] = v.decode('utf-8')
+            else:
+                out[k] = v
 
-        if self.data['daemon_version'] < '2':
-            return {
-                'net_sent_sec_bytes': response['upload_rate'],
-                'net_recv_sec_bytes': response['download_rate'],
-                'net_recv_bytes': response['total_download'],
-                'net_sent_bytes': response['total_upload']
-            }
-        else:
-            return {k.replace('.', '_'): v for k, v in response.items()}
-
-    def _send_request(self, payload):
-        if self.session is None:
-            self.session = requests.Session()
-
-        r = self.session.post('http://{}:{}/json'.format(self.host, self.port), headers=self.headers, json=payload)
-        if r.ok:
-            content = r.json()
-            if not content['error']:
-                return content['result']
-
-    def _gen_request(self, method, args=None, kwargs=None):
-        req = {"method": method, "id": self.id}
-        if args is None:
-            req['params'] = []
-        else:
-            req['params'] = args
-
-        return req
+        return out

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -8,6 +8,7 @@ from i3pystatus.core.util import bytes_info_dict
 class Deluge(IntervalModule):
     """
     Deluge torrent module
+    You will need to enable the web ui in deluge.
     Requires `requests`
 
     .. rubric:: Formatters:

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -43,7 +43,7 @@ class Deluge(IntervalModule):
         ('port', 'port of deluge server (default: 58846)'),
         ('password', 'password to authenticate to deluge (default: deluge)'),
         ('path', 'override "download path" server-side when checking space used/free'),
-        ('libtorrent_stats', 'bool. set to True to pull all stats from libtorrent '
+        ('libtorrent_stats', 'Deluge 2+ only. bool. set to True to pull all stats from libtorrent '
                              '(may cause high memory usage on older machines)(default: False)',
          )
     )

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -49,7 +49,7 @@ class Deluge(IntervalModule):
     libtorrent_stats = False
     rounding = 2
 
-    format = '{num_torrents} {free_space_bytes}'
+    format = '⛆{num_torrents} ✇{free_space_bytes}'
 
     headers = {
         'Content-Type': 'application/json',

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -56,15 +56,13 @@ class Deluge(IntervalModule):
         'Accept': 'application/json',
     }
 
-    id = int(time.time()) # something random
+    id = int(time.time())  # something random
 
     def init(self):
         self.session = None
 
     def run(self):
-        format_values = dict(
-            num_torrents='', free_space='', daemon_version='', used_space='',
-                             )
+        format_values = dict(num_torrents='', free_space='', daemon_version='', used_space='')
 
         if not self.check_session():
             self.authenticate()

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -10,20 +10,20 @@ class Deluge(IntervalModule):
     Deluge torrent module
     Requires `requests`
 
-    Formatters:
+    .. rubric:: Formatters:
 
     * `{num_torrents}`   - number of torrents in deluge
     * `{free_space_bytes}`     - bytes free in path
     * `{daemon_version}` - current version of deluge running on the server
     * `{used_space_bytes}`     - bytes used in path
 
-    Unlisted Formatters:
+    .. rubric:: Unlisted Formatters:
 
     due to the sheer number of options in libtorrent, if you enable collection of
     libtorrent stats the keys are in the link below, just click 'session statistics'
     from the table of contents (for compatibility reasons, replace the fullstop in
     the name with an underscore, eg `net.recv_bytes` -> `net_recv_bytes`.
-        <https://www.libtorrent.org/manual-ref.html#session-statistics>
+    <https://www.libtorrent.org/manual-ref.html#session-statistics>
 
     """
     # TODO: convert this module to run off a python library rather then requests

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -89,7 +89,6 @@ class Deluge(IntervalModule):
 
             self.last_tick = float(this_tick)
             self.last_session_statistics = dict(format_values)
-            self.parse_values(format_values)
 
         torrents = self.get_torrents_status()
         if torrents:
@@ -101,6 +100,8 @@ class Deluge(IntervalModule):
             format_values['used_space_bytes'] = self.get_path_size(self.path)
         if 'daemon_version' in self.format:
             format_values['daemon_version'] = self.get_version()
+
+        self.parse_values(format_values)
 
         self.data = format_values
         self.output = {

--- a/i3pystatus/deluge.py
+++ b/i3pystatus/deluge.py
@@ -1,0 +1,152 @@
+import requests
+import time
+
+from i3pystatus import IntervalModule
+from i3pystatus.core.util import bytes_info_dict
+
+
+class Deluge(IntervalModule):
+    """
+    Deluge torrent module
+    Requires `requests`
+
+    Formatters:
+
+    * `{num_torrents}`   - number of torrents in deluge
+    * `{free_space_bytes}`     - bytes free in path
+    * `{daemon_version}` - current version of deluge running on the server
+    * `{used_space_bytes}`     - bytes used in path
+
+    Unlisted Formatters:
+
+    due to the sheer number of options in libtorrent, if you enable collection of
+    libtorrent stats the keys are in the link below, just click 'session statistics'
+    from the table of contents (for compatibility reasons, replace the fullstop in
+    the name with an underscore, eg `net.recv_bytes` -> `net_recv_bytes`.
+        <https://www.libtorrent.org/manual-ref.html#session-statistics>
+
+    """
+    # TODO: convert this module to run off a python library rather then requests
+    #       i chose requests because at the time 2.0.0-b isnt supported by any
+    #       libraries.
+
+    settings = (
+        ('format'),
+        ('rounding', 'number of decimal places to round numbers too'),
+        ('host', 'address of deluge server (default: 127.0.0.1)'),
+        ('port', 'port of deluge server (default: 58846)'),
+        ('password', 'password to authenticate to deluge (default: deluge)'),
+        ('path', 'override "download path" server-side when checking space used/free'),
+        ('libtorrent_stats', 'bool. set to True to pull all stats from libtorrent '
+                             '(may cause high memory usage on older machines)(default: False)',
+         )
+    )
+
+    host = '127.0.0.1'
+    port = 8112
+    password = 'deluge'
+    path = None
+    libtorrent_stats = False
+    rounding = 2
+
+    format = '{num_torrents} {free_space_bytes}'
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    id = int(time.time()) # something random
+
+    def init(self):
+        self.session = None
+
+    def run(self):
+        format_values = dict(
+            num_torrents='', free_space='', daemon_version='', used_space='',
+                             )
+
+        if not self.check_session():
+            self.authenticate()
+
+        torrents = self.get_torrents_status()
+        if torrents:
+            format_values['num_torrents'] = len(torrents)
+
+        if 'free_space_bytes' in self.format:
+            format_values['free_space_bytes'] = self.get_free_space(self.path)
+        if 'used_space_bytes' in self.format:
+            format_values['used_space_bytes'] = self.get_path_size(self.path)
+        if 'daemon_version' in self.format:
+            format_values['daemon_version'] = self.get_version()
+        if self.libtorrent_stats:
+            format_values.update(self.get_session_statistics())
+
+        self.parse_values(format_values)
+        self.data = format_values
+        self.output = {
+            'full_text': self.format.format(**self.data)
+        }
+
+    def parse_values(self, values):
+        for k, v in values.items():
+            if k.endswith('_bytes'):
+                values[k] = '{value:.{round}f}{unit}'.format(round=self.rounding, **bytes_info_dict(v))
+
+    def authenticate(self):
+        payload = self._gen_request('auth.login', [self.password])
+        return self._send_request(payload)
+
+    def check_session(self):
+        payload = self._gen_request('auth.check_session', [])
+        return self._send_request(payload)
+
+    def get_path_size(self, path=None):
+        """
+        get used space of path in bytes (default: download location)
+        """
+        if path is None:
+            path = []
+        payload = self._gen_request('core.get_path_size', path)
+        return self._send_request(payload)
+
+    def get_free_space(self, path=None):
+        """
+        get free space of path in bytes (default: download location)
+        """
+        if path is None:
+            path = []
+        payload = self._gen_request('core.get_free_space', path)
+        return self._send_request(payload)
+
+    def get_torrents_status(self, torrent_id=None, keys=None):
+        if torrent_id is None:
+            torrent_id = []
+        if keys is None:
+            keys = []
+        payload = self._gen_request('core.get_torrents_status', [torrent_id, keys])
+        return self._send_request(payload)
+
+    def get_version(self):
+        payload = self._gen_request('daemon.get_version', [])
+        return self._send_request(payload)
+
+    def get_session_statistics(self):
+        payload = self._gen_request('core.get_session_status', [None])
+        return {k.replace('.', '_'): v for k, v in self._send_request(payload).items()}
+
+    def _send_request(self, payload):
+        if self.session is None:
+            self.session = requests.Session()
+
+        r = self.session.post('http://{}:{}/json'.format(self.host, self.port), headers=self.headers, json=payload)
+        if r.ok:
+            content = r.json()
+            if not content['error']:
+                return content['result']
+
+    def _gen_request(self, method, params=None):
+        req = {"method": method, "id": self.id}
+        if params is not None:
+            req['params'] = params
+        return req


### PR DESCRIPTION
Module to view data on a running deluge daemon.
As deluge works in a client/server model regardless of whether or not the daemon is on the same machine as the client, this can be used for a local daemon.

I haven't done any solid benchmarks, but based on a cursory look in `htop` and `dstat` the performance impact of even grabbing all of the `libtorrent` stats doesn't seem too intensive (barely cracked 2% cpu on my ryzen7)