### PR TITLE
Fix TypeError when not using network traffic in format string

### DIFF
--- a/i3pystatus/network.py
+++ b/i3pystatus/network.py
@@ -481,7 +481,10 @@ class Network(IntervalModule, ColorRangeModule):
                 format_values[metric] = '{value:.{round}f}{unit}'.format(
                     round=self.round_size, **bytes_info_dict(format_values[metric]))
             else:
-                format_values[metric] = '{:.{round}f}'.format(format_values[metric] / self.divisor, round=self.round_size)
+                try:
+                    format_values[metric] = '{:.{round}f}'.format(format_values[metric] / self.divisor, round=self.round_size)
+                except TypeError:
+                    pass
 
         self.data = format_values
         self.output = {


### PR DESCRIPTION
These formatters are initialized as strings, so when they're not used we don't use use the code that updates the network counters, and the result is that we attempt to divide an empty string by the divisor value (an integer), resulting in a TypeError.

This ignores these errors, letting these formatters remain as empty strings.