### PR TITLE
[wip] adding new module nix-channel

### DIFF
--- a/i3pystatus/nix-channels.py
+++ b/i3pystatus/nix-channels.py
@@ -2,6 +2,7 @@
 import urllib.request
 from i3pystatus.core.util import internet, require
 from i3pystatus import IntervalModule, logger
+import datetime
 
 class NixChannels(IntervalModule):
 
@@ -11,12 +12,14 @@ class NixChannels(IntervalModule):
     settings = (
         ("color", "Text color when online"),
         ('color_offline', 'Text color when offline'),
-        # ('format_online', 'Status text when online'),
+        ('channel', 'Name of the channel'),
+        ('format_online', 'Status text when online'),
         # ('format_offline', 'Status text when offline'),
         ("interval", "Update interval"),
     )
 
     color = '#ffffff'
+    channel = 'nixos-unstable'
     color_offline = '#ff0000'
     format_online = 'online'
     format_offline = 'offline'
@@ -24,12 +27,26 @@ class NixChannels(IntervalModule):
 
     @require(internet)
     def run(self):
-        url = "https://nixos.org/channels/nixos-unstable"
+        url = "https://nixos.org/channels/%s" % self.channel
         conn = urllib.request.urlopen(url, timeout=30)
         last_modified = conn.headers['last-modified']
+
+        # outstr = today.strftime(self.prefixformat) + " "
+        span = last_update - datetime.now()
 
         # if internet():
         self.output = {
             "color": self.color,
-            "full_text": "nixos-unstable: %s" % (last_modified)
+            "full_text": "nixos-unstable: %s" % (span)
         }
+
+
+    # upon update trigger notification ?
+    # def report(self):
+    #     DesktopNotification(
+    #         title=formatp(self.format_summary, **self.data).strip(),
+    #         body="\n".join(self.notif_body.values()),
+    #         icon=self.notification_icon,
+    #         urgency=1,
+    #         timeout=0,
+    #     ).display()

--- a/i3pystatus/nix-channels.py
+++ b/i3pystatus/nix-channels.py
@@ -1,0 +1,35 @@
+# import os
+import urllib.request
+from i3pystatus.core.util import internet, require
+from i3pystatus import IntervalModule, logger
+
+class NixChannels(IntervalModule):
+
+    """
+    Gets update count for nix channels
+    """
+    settings = (
+        ("color", "Text color when online"),
+        ('color_offline', 'Text color when offline'),
+        # ('format_online', 'Status text when online'),
+        # ('format_offline', 'Status text when offline'),
+        ("interval", "Update interval"),
+    )
+
+    color = '#ffffff'
+    color_offline = '#ff0000'
+    format_online = 'online'
+    format_offline = 'offline'
+    interval = 3600
+
+    @require(internet)
+    def run(self):
+        url = "https://nixos.org/channels/nixos-unstable"
+        conn = urllib.request.urlopen(url, timeout=30)
+        last_modified = conn.headers['last-modified']
+
+        # if internet():
+        self.output = {
+            "color": self.color,
+            "full_text": "nixos-unstable: %s" % (last_modified)
+        }

--- a/i3pystatus/nix-channels.py
+++ b/i3pystatus/nix-channels.py
@@ -1,7 +1,7 @@
 # import os
 import urllib.request
 from i3pystatus.core.util import internet, require
-from i3pystatus import IntervalModule, logger
+from i3pystatus import IntervalModule
 import datetime
 
 class NixChannels(IntervalModule):
@@ -11,10 +11,7 @@ class NixChannels(IntervalModule):
     """
     settings = (
         ("color", "Text color when online"),
-        ('color_offline', 'Text color when offline'),
-        ('channel', 'Name of the channel'),
-        ('format_online', 'Status text when online'),
-        # ('format_offline', 'Status text when offline'),
+        ('channel', 'Name of the channel. Must be tracked by https://channels.nix.gsc.io/'),
         ("interval", "Update interval"),
     )
 
@@ -29,11 +26,9 @@ class NixChannels(IntervalModule):
 
     @require(internet)
     def run(self):
-        url = f"https://channels.nix.gsc.io/{self.channel}/latest-url"
+        url = f"https://channels.nix.gsc.io/{self.channel}/history-url"
         conn = urllib.request.urlopen(url, timeout=30)
         advancement_timestamp = conn.read().decode().split()[-1]
-        # print()
-        # last_modified = conn.headers['last-modified']
         last_modified = datetime.datetime.fromtimestamp(int(advancement_timestamp))
         # outstr = today.strftime(self.prefixformat) + " "
         span = datetime.datetime.now() - last_modified
@@ -41,7 +36,7 @@ class NixChannels(IntervalModule):
         # if internet():
         self.output = {
             "color": self.color,
-            "full_text": "%s" % (span)
+            "full_text": f"{self.channel}: %s" % (span)
         }
 
 

--- a/i3pystatus/nix-channels.py
+++ b/i3pystatus/nix-channels.py
@@ -23,21 +23,25 @@ class NixChannels(IntervalModule):
     color_offline = '#ff0000'
     format_online = 'online'
     format_offline = 'offline'
+    # https://channels.nix.gsc.io/ is a non official service and requests to not be polled
+    # more frequently than every 15 mn
     interval = 3600
 
     @require(internet)
     def run(self):
-        url = "https://nixos.org/channels/%s" % self.channel
+        url = f"https://channels.nix.gsc.io/{self.channel}/latest-url"
         conn = urllib.request.urlopen(url, timeout=30)
-        last_modified = conn.headers['last-modified']
-
+        advancement_timestamp = conn.read().decode().split()[-1]
+        # print()
+        # last_modified = conn.headers['last-modified']
+        last_modified = datetime.datetime.fromtimestamp(int(advancement_timestamp))
         # outstr = today.strftime(self.prefixformat) + " "
-        span = last_update - datetime.now()
+        span = datetime.datetime.now() - last_modified
 
         # if internet():
         self.output = {
             "color": self.color,
-            "full_text": "nixos-unstable: %s" % (span)
+            "full_text": "%s" % (span)
         }
 
 


### PR DESCRIPTION
Addresses https://github.com/enkore/i3pystatus/issues/620 .

My goal is to have something like https://howoldis.herokuapp.com/ in i3pystatus.
that fetches when the channel was last updated
TODO: 
- cleanup 
- make channel configurable
- display elapsed time since last update instead.

Feel free to takeover.