### PR TITLE
core/init: don't set default_hints with anything

### DIFF
--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -66,7 +66,7 @@ class Status:
     def __init__(self, standalone=True, click_events=True, interval=1,
                  input_stream=None, logfile=None, internet_check=None,
                  keep_alive=False, logformat=DEFAULT_LOG_FORMAT,
-                 default_hints={"markup": "none"}):
+                 default_hints=None):
         self.standalone = standalone
         self.default_hints = default_hints
         self.click_events = standalone and click_events
@@ -113,10 +113,10 @@ class Status:
 
         # Merge the module's hints with the default hints
         # and overwrite any duplicates with the hint from the module
-        merged_hints = self.default_hints.copy()
-        if 'hints' in kwargs:
-            merged_hints.update(kwargs['hints'])
-        kwargs['hints'] = merged_hints
+        hints = self.default_hints.copy() if self.default_hints else {}
+        hints.update(kwargs.get('hints', {}))
+        if hints:
+            kwargs['hints'] = hints
 
         try:
             return self.modules.append(module, *args, **kwargs)


### PR DESCRIPTION
Hi, I want to fix https://github.com/ultrabug/py3status/issues/1733.

https://github.com/enkore/i3pystatus/blob/8638ca0b1fa59d642d4892ab3a0c100dd77b8b23/i3pystatus/core/modules.py#L62

If I understand this right, the permalink above showed that the modules already are using the same hints everywhere for a different reason so we shouldn't need to set `default_hints` with same hints.

With same hints out of way, this also avoid setting `hints` with an empty value which is still needed to make `py3status`'s `i3pystatus` module work again. Things looks okay on my side. Please review.

Unrelated. I think it would be more nice/consistent to use `hints` instead of `default_hints`. Cheers.


