### PR TITLE
mpd: use empty dict on stopped playback state

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -133,7 +133,10 @@ cleartext to the server.)"),
         try:
             status = self._mpd_command(self.s, "status")
             playback_state = status["state"]
-            currentsong = self._mpd_command(self.s, "currentsong")
+            if playback_state == "stop":
+                currentsong = {}
+            else:
+                currentsong = self._mpd_command(self.s, "currentsong")
         except Exception:
             if self.hide_inactive:
                 self.output = {


### PR DESCRIPTION
This assigns an empty dict instead of last stored `currentsong` dict.

Fixes https://github.com/enkore/i3pystatus/issues/207.
