### PR TITLE
mem: print zero used_mem instead of negative used_mem

### DIFF
--- a/i3pystatus/mem.py
+++ b/i3pystatus/mem.py
@@ -44,11 +44,6 @@ class Mem(IntervalModule):
     def run(self):
         memory_usage = psutil.virtual_memory()
 
-        if psutil.version_info < (4, 4, 0):
-            used = memory_usage.used - memory_usage.cached - memory_usage.buffers
-        else:
-            used = memory_usage.used
-
         if memory_usage.percent >= self.alert_percentage:
             color = self.alert_color
         elif memory_usage.percent >= self.warn_percentage:
@@ -57,7 +52,7 @@ class Mem(IntervalModule):
             color = self.color
 
         cdict = {
-            "used_mem": used / self.divisor,
+            "used_mem": max(0, memory_usage.used) / self.divisor,
             "avail_mem": memory_usage.available / self.divisor,
             "total_mem": memory_usage.total / self.divisor,
             "percent_used_mem": memory_usage.percent,


### PR DESCRIPTION
The problem is not caused by `mem` module. It comes from `psutil` or the data.

Please make a decision.
1) Print negative value as-is. Users have to accept this issue.
2) Print `0.0` instead. Users won't see this issue.  (Current)

I remove if statement for `psutil` old version too.

Closes https://github.com/enkore/i3pystatus/issues/580.