### PR TITLE
setup: add python_requires='>=3.5'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 python:
-  - "3.4"
+  - "3.5"
 install:
   - "pip install -r dev-requirements.txt"
 script: "./ci-build.sh"

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ i3pystatus
 i3pystatus is a large collection of status modules compatible with i3bar from the i3 window manager.
 
 :License: MIT
-:Python: 3.4+
+:Python: 3.5+
 :Governance: Patches that don't break the build (Travis or docs) are generally just merged. This is a "do-it-yourself" project, so to speak.
 :Releases: No further releases are planned. Install it from Git.
 
@@ -15,7 +15,7 @@ Installation
 ------------
 
 **Supported Python versions**
-    i3pystatus requires Python 3.4 or newer and is not compatible with
+    i3pystatus requires Python 3.5 or newer and is not compatible with
     Python 2.x. Some modules require additional dependencies
     documented in the docs.
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,12 @@ setup(name="i3pystatus",
           "Environment :: X11 Applications",
           "License :: OSI Approved :: MIT License",
           "Operating System :: POSIX :: Linux",
-          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
           "Topic :: Desktop Environment :: Window Managers",
       ],
+      python_requires='>=3.5',
       packages=find_packages(include=['i3pystatus', 'i3pystatus.*']),
       entry_points={
           "console_scripts": [


### PR DESCRIPTION
I aim to close two issues with this PR. Is `3.6` okay or do you prefer `3.5` instead? See [Debian/stable](https://packages.debian.org/stable/python/python3-all).

1) Bumping to `Python >= 3.6` would allow `f-strings` and other features. Closes https://github.com/enkore/i3pystatus/issues/430.

2) `i3pystatus requires Python '>=3.6' but the running Python is 2.7.16` Closes https://github.com/enkore/i3pystatus/issues/536.

EDIT: FWIW you still have some Debian Stable users based on issue comments.