### PR TITLE
alsa: set card with default -1 instead of hardcoded 0

### DIFF
--- a/i3pystatus/alsa.py
+++ b/i3pystatus/alsa.py
@@ -41,7 +41,7 @@ class ALSA(IntervalModule):
     format_muted = None
     mixer = "Master"
     mixer_id = 0
-    card = 0
+    card = -1
     channel = 0
     increment = 5
 


### PR DESCRIPTION
I think https://github.com/enkore/i3pystatus/issues/307 may have been caused by hardcoded `0` instead of default `-1` according to https://larsimmisch.github.io/pyalsaaudio/libalsaaudio.html#mixer-objects. 
```python
class alsaaudio.Mixer(control='Master', id=0, cardindex=-1, device='default')`
```
... which might explain this exception...

>The exception is quite specific:
>> alsaaudio.ALSAAudioError: Unable to find mixer control Master,0 [hw:0]
>
>And reveals that the settings are correctly passed to pyalsaaudio. Could it be a permission problem? Or maybe some application (DAW?) you are running opens this ALSA card exclusively?

Maybe it can't work with `0` and wanted `1`... or `0` is something else such as mics?
 
Also, when I compare card settings, I find `-1` card printing volume percentage more accurate.
```python
status.register(
    "alsa",
    format="♪: {volume} {card}",
    card=0,
)
status.register(
    "alsa",
    format="♪: {volume} {card}",
    card=-1,
)
```

I'd like to use this PR to close https://github.com/enkore/i3pystatus/issues/307. OP no longer uses `i3pystatus` too.