### PR TITLE
[github] fixed status api call

### DIFF
--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -325,8 +325,6 @@ class Github(IntervalModule):
         self.logger.debug('Making GitHub Status API request to %s', url)
         try:
             with urlopen(url) as content:
-                # self.logger.log(5, 'url \'%s\' content: ', url)
-                # self.logger.log(5, content)
                 try:
                     content_type = dict(content.getheaders())['Content-Type']
                     charset = re.search(r'charset=(.*)', content_type).group(1)

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -444,8 +444,7 @@ class Github(IntervalModule):
             if 'status' in self.current_status.keys():
                 status_data = self.current_status.get('status')
                 if 'description' in status_data.keys():
-                    status_key = status_data.get('description')
-            
+                    status_key = status_data.get('description')            
             self.data['status'] = self.status.get(status_key)
 
             if self.previous_status is not None:

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -445,7 +445,7 @@ class Github(IntervalModule):
                 status_data = self.current_status.get('status')
                 if 'description' in status_data.keys():
                     status_key = status_data.get('description')
-            self.logger.error('status: %s unkown: %s', self.current_status.get('status'), self.unknown_status)
+            
             self.data['status'] = self.status.get(status_key)
 
             if self.previous_status is not None:

--- a/i3pystatus/github.py
+++ b/i3pystatus/github.py
@@ -444,7 +444,7 @@ class Github(IntervalModule):
             if 'status' in self.current_status.keys():
                 status_data = self.current_status.get('status')
                 if 'description' in status_data.keys():
-                    status_key = status_data.get('description')            
+                    status_key = status_data.get('description')
             self.data['status'] = self.status.get(status_key)
 
             if self.previous_status is not None:


### PR DESCRIPTION
The original code was calling into `status.github.com/api.json` which is redirecting into `https://www.githubstatus.com/`, hence not working properly - hence the change to call into `https://www.githubstatus.com/api/v2/status.json`

the expected JSON data seems to have changed as well