### PR TITLE
Some fixes to backlight module

### DIFF
--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -76,13 +76,9 @@ class Backlight(File):
             "percentage": -1
         }
 
-        format = self.format_no_backlight
-        if not format:
-            format = self.format
-
         self.data = cdict
         self.output = {
-            "full_text": format.format(**cdict),
+            "full_text": self.format_no_backlight.format(**cdict),
             "color": self.color
         }
 

--- a/i3pystatus/backlight.py
+++ b/i3pystatus/backlight.py
@@ -44,6 +44,8 @@ class Backlight(File):
     on_downscroll = "darker"
 
     def init(self):
+        self.has_xbacklight = shutil.which("xbacklight") is not None
+
         self.base_path = self.base_path.format(backlight=self.backlight)
         backlight_entries = sorted(glob.glob(self.base_path))
 
@@ -53,7 +55,6 @@ class Backlight(File):
             return
 
         self.base_path = backlight_entries[0]
-        self.has_xbacklight = shutil.which("xbacklight") is not None
 
         # xbacklight expects a percentage as parameter. Calculate the percentage
         # for one step (if smaller xbacklight doesn't increases the brightness)


### PR DESCRIPTION
This PR brings 2 fixes to `backlight` module:
- It fixes the following exception when the user does not have a backlight in the system (i.e. Desktop) and tries to adjust the brightness:
```
2019-05-27 23:05:53,754 [CRITICAL][i3pystatus.backlight.Backlight 175] Exception while processing button callback: AttributeError("'Backlight' object has no attribute 'has_xbacklight'")
2019-05-27 23:05:53,754 [CRITICAL][i3pystatus.backlight.Backlight 176] Traceback (most recent call last):
  File "/nix/store/v0km55axl2452hnsazbc1y8k0zdmcsbv-i3pystatus-unstable-2019-02-10/lib/python3.7/site-packages/i3pystatus/core/modules.py", line 162, in __button_callback_handler
    call_callback(getattr(self, cb), *args, **kwargs)
  File "/nix/store/v0km55axl2452hnsazbc1y8k0zdmcsbv-i3pystatus-unstable-2019-02-10/lib/python3.7/site-packages/i3pystatus/core/modules.py", line 133, in call_callback
    cb(*args, **kwargs)
  File "/nix/store/v0km55axl2452hnsazbc1y8k0zdmcsbv-i3pystatus-unstable-2019-02-10/lib/python3.7/site-packages/i3pystatus/backlight.py", line 93, in darker
    if self.has_xbacklight:
AttributeError: 'Backlight' object has no attribute 'has_xbacklight'
```
- It allows the user to set `format_no_backlight` to empty string and hide `backlight` module in case the system does not have a backlight (i.e.:, again, in a Desktop). If you set to an empty string nowadays it results the same output as the default one, resulting in something like `Brightness: -1` output.