### PR TITLE
pulseaudio: remove output when sink is gone

### DIFF
--- a/i3pystatus/pulseaudio/__init__.py
+++ b/i3pystatus/pulseaudio/__init__.py
@@ -147,7 +147,7 @@ class PulseAudio(Module, ColorRangeModule):
 
         self.request_update(context)
 
-    def sink_info_cb(self, context, sink_info_p, _, __):
+    def sink_info_cb(self, context, sink_info_p, eol, _):
         """Updates self.output"""
         if sink_info_p:
             sink_info = sink_info_p.contents
@@ -197,6 +197,9 @@ class PulseAudio(Module, ColorRangeModule):
                     selected=selected),
             }
 
+            self.send_output()
+        elif eol < 0:
+            self.output = None
             self.send_output()
 
     def change_sink(self):


### PR DESCRIPTION
When `sink` is set and you have USB card or Bluetooth headset.

When the sink is created, the output is set and the module appear.

But when the sink is deleted, the output is not deleted, and the module
stay.

This change detects when the sink is deleted and delete the output.