### PR TITLE
Allowing to set the duration format for the timewarrior module

### DIFF
--- a/i3pystatus/timewarrior.py
+++ b/i3pystatus/timewarrior.py
@@ -29,6 +29,7 @@ class Timewarrior(IntervalModule):
 
     settings = (
         ('format', 'format string'),
+        ('duration_format', 'duration format string'),
         ('enable_stop', 'Allow right click to stop tracking'),
         ('enable_continue', 'ALlow right click to continue tracking'),
         ('color_running', '#00FF00'),


### PR DESCRIPTION
Currently, only one format is available for the timewarrior module, and it is not a very convenient one. By adding one row, the duration_format setting is changable from the configuration file.

I am not sure if I had to update the documentation, I suppose is it automatically generated from the code, right?