### PR TITLE
Fix the spotify module

### DIFF
--- a/i3pystatus/spotify.py
+++ b/i3pystatus/spotify.py
@@ -5,4 +5,4 @@ class Spotify(NowPlaying):
     """
     Get Spotify info using dbus interface. Based on `now_playing`_ module.
     """
-    player_name = "spotify"
+    player = "spotify"


### PR DESCRIPTION
The now_playing module does not use player_name anymore so the spotify module is broken.
Change it to use player so it works correctly.