### PR TITLE
utils/gpu: fix nvidia-smi parsing for new nvidia-smi that uses (N/A) when unsupported

### DIFF
--- a/i3pystatus/utils/gpu.py
+++ b/i3pystatus/utils/gpu.py
@@ -1,9 +1,19 @@
 import subprocess
 from collections import namedtuple
+from typing import Optional
 
 GPUUsageInfo = namedtuple('GPUUsageInfo', ['total_mem', 'avail_mem', 'used_mem',
                                            'temp', 'percent_fan',
                                            'usage_gpu', 'usage_mem'])
+
+
+def _convert_nvidia_smi_value(value) -> Optional[int]:
+    value = value.lower()
+    # If value contains 'not' or 'N/A' - it is not supported for this GPU
+    # (in fact, for now nvidia-smi returns '[Not Supported]' or '[N/A]' depending of its version)
+    if "not" in value or "n/a" in value:
+        return None
+    return int(value)
 
 
 def query_nvidia_smi(gpu_number) -> GPUUsageInfo:
@@ -37,7 +47,6 @@ def query_nvidia_smi(gpu_number) -> GPUUsageInfo:
     output = output.decode('utf-8').split("\n")[gpu_number].strip()
     values = output.split(", ")
 
-    # If value contains 'not' - it is not supported for this GPU (in fact, for now nvidia-smi returns '[Not Supported]')
-    values = [None if ("not" in value.lower()) else int(value) for value in values]
+    values = [_convert_nvidia_smi_value(value) for value in values]
 
     return GPUUsageInfo(*values)


### PR DESCRIPTION
When upgrading my nvidia drivers to , I noticed that the output `nvidia-smi` changed:

```
$ nvidia-smi --query-gpu=memory.total,memory.free,memory.used,temperature.gpu,fan.speed,utilization.gpu,utilization.memory --format=csv,noheader,nounits 
2004, 2004, 0, 44, [N/A], 0, 0
```
instead of the old:

```
gpu=memory.total,memory.free,memory.used,temperature.gpu,fan.speed,utilization.gpu,utilization.memory --format=csv,noheader,nounits 
2004, 2004, 0, 44, [Not Supported], 0, 0
```

This PR fix this issue.