### PR TITLE
Fix "NowPlaying: KeyError: None"

### DIFF
--- a/i3pystatus/now_playing.py
+++ b/i3pystatus/now_playing.py
@@ -194,6 +194,10 @@ https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
             if hasattr(self, "data"):
                 del self.data
             return
+        except KeyError:
+            if self.hide_no_player:
+                self.output = None
+            return
 
     def playpause(self):
         self.player_command('PlayPause')


### PR DESCRIPTION
This is a bad workaround, as it only catches the exception and doesn't address the problem at the place where it's thrown.
But I don't have time to study the code properly, as it's quite late in the evening right now.

If someone else wants to improve on this before I get to it, feel free to.