### PR TITLE
Team colorization updates for scores backends

### DIFF
--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -158,7 +158,7 @@ class MLB(ScoresBackend):
         'OAK': '#006659',
         'PHI': '#E81828',
         'PIT': '#FFCC01',
-        'SD': '#285F9A',
+        'SD': '#FFC425',
         'SEA': '#2E8B90',
         'SF': '#FD5A1E',
         'STL': '#B53B30',

--- a/i3pystatus/scores/nhl.py
+++ b/i3pystatus/scores/nhl.py
@@ -105,6 +105,7 @@ class NHL(ScoresBackend):
     * **OTT** — Ottawa Senators
     * **PHI** — Philadelphia Flyers
     * **PIT** — Pittsburgh Penguins
+    * **SEA** — Seattle Kraken
     * **SJS** — San Jose Sharks
     * **STL** — St. Louis Blues
     * **TBL** — Tampa Bay Lightning
@@ -184,6 +185,7 @@ class NHL(ScoresBackend):
         'OTT': '#C50B2F',
         'PHI': '#FF690B',
         'PIT': '#FFB81C',
+        'SEA': '#96D8D8',
         'SJS': '#007888',
         'STL': '#1764AD',
         'TBL': '#296AD5',


### PR DESCRIPTION
MLB: San Diego changed color scheme for 2020.
NHL: Adding Seattle Kraken (2021 expansion team)