### PR TITLE
pango: don't expand '&' when it is part of an HTML escape sequence

### DIFF
--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -1,3 +1,4 @@
+import html
 import inspect
 import traceback
 
@@ -260,14 +261,16 @@ class Module(SettingsBase):
 
         Can be called multiple times (`&amp;` won't change to `&amp;amp;`).
         """
-        def replace(s):
-            s = s.split("&")
-            out = s[0]
-            for i in range(len(s) - 1):
-                if s[i + 1].startswith("amp;"):
-                    out += "&" + s[i + 1]
+        def replace(text):
+            components = text.split("&")
+            out = components[0]
+            for item in components[1:]:
+                if item.startswith("amp;") \
+                        or (not item.startswith("amp;")
+                            and html.unescape(f'&{item}') != f'&{item}'):
+                    out += "&" + item
                 else:
-                    out += "&amp;" + s[i + 1]
+                    out += "&amp;" + item
             return out
 
         if "full_text" in self.output.keys():


### PR DESCRIPTION
Resolves #794.