### PR TITLE
mpd: add option "time_format" to module

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Erik Johnson
 enkore
 facetoe
 Frank Tackitt
+Franziska Kunsmann
 gacekjk
 Georg Sieber
 Goran Mekić

--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -75,6 +75,7 @@ fields, if truncated, ellipsis are appended as indicator. It's applied \
 fields specefied in truncate_fields are truncated equaly. If truncated, \
 ellipsis are appended as indicator. It's applied *after* max_field_len. Value \
 of 0 disables this."),
+        ("time_format", "format string for 'pos' and 'len' fields"),
         ("truncate_fields", "fields that will be truncated if exceeding \
 max_field_len or max_len."),
         ("hide_inactive", "Hides status information when MPD is not running"),
@@ -96,6 +97,7 @@ cleartext to the server.)"),
     color_map = {}
     max_field_len = 25
     max_len = 100
+    time_format = "%M:MS"
     truncate_fields = ("title", "album", "artist", "album_artist")
     hide_inactive = False
     on_leftclick = "switch_playpause"
@@ -156,8 +158,8 @@ cleartext to the server.)"),
             "album": currentsong.get("Album", ""),
             "artist": currentsong.get("Artist", ""),
             "album_artist": currentsong.get("AlbumArtist", ""),
-            "song_length": TimeWrapper(currentsong.get("Time", 0)),
-            "song_elapsed": TimeWrapper(float(status.get("elapsed", 0))),
+            "song_length": TimeWrapper(currentsong.get("Time", 0), default_format=self.time_format),
+            "song_elapsed": TimeWrapper(float(status.get("elapsed", 0)), default_format=self.time_format),
             "bitrate": int(status.get("bitrate", 0)),
         }
 


### PR DESCRIPTION
This allows customizing the time display in MPD module.

For example, i'm usually playing long (2+ hour) mixes of some DJs, so only having %M:%S is not sufficient for me.

Default behaviour is unchanged.

I know one could also use https://i3pystatus.readthedocs.io/en/latest/configuration.html#timewrapper, but I think *one* setting for both is better.