### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -136,7 +136,7 @@ If no arguments were provided, ``i3pystatus`` script works as an example of
 Formatting
 ----------
 
-All modules let you specifiy the exact output formatting using a
+All modules let you specify the exact output formatting using a
 `format string <http://docs.python.org/3/library/string.html#formatstrings>`_, which
 gives you a great deal of flexibility.
 

--- a/i3pystatus/calendar/google.py
+++ b/i3pystatus/calendar/google.py
@@ -57,7 +57,7 @@ class Google(CalendarBackend):
     this will open a browser window for auth, and save a token to `credential_path`. you will need to reload i3poystatus
     afterwards
 
-    If you already have a token `credentials_json` is not required (though highly recomended incase your token gets broken)
+    If you already have a token `credentials_json` is not required (though highly recommended incase your token gets broken)
 
     .. rubric:: Available formatters
 

--- a/i3pystatus/coin.py
+++ b/i3pystatus/coin.py
@@ -8,7 +8,7 @@ from i3pystatus.core.util import internet, require
 
 class Coin(IntervalModule):
     """
-    Fetches live data of all cryptocurrencies availible at coinmarketcap <https://coinmarketcap.com/>.
+    Fetches live data of all cryptocurrencies available at coinmarketcap <https://coinmarketcap.com/>.
     Coin setting should be equal to the 'id' field of your coin in <https://api.coinmarketcap.com/v1/ticker/>.
 
     Example coin settings: bitcoin, bitcoin-cash, ethereum, litecoin, dash, lisk.

--- a/i3pystatus/core/modules.py
+++ b/i3pystatus/core/modules.py
@@ -215,7 +215,7 @@ class Module(SettingsBase):
 
         :param button: The ID of button event received from i3bar.
         :param kwargs: Further information received from i3bar like the
-         positions of the mouse where the click occured.
+         positions of the mouse where the click occurred.
         :return: Returns ``True`` if a valid callback action was executed.
          ``False`` otherwise.
         """

--- a/i3pystatus/ping.py
+++ b/i3pystatus/ping.py
@@ -8,7 +8,7 @@ class Ping(IntervalModule):
     This module display the ping value between your computer and a host.
 
     ``switch_state`` callback can disable the Ping when desired.
-    ``host`` propertie can be changed for set a specific host.
+    ``host`` property can be changed for set a specific host.
 
     .. rubric:: Available formatters
 

--- a/i3pystatus/sabnzbd.py
+++ b/i3pystatus/sabnzbd.py
@@ -62,7 +62,7 @@ class sabnzbd(IntervalModule):
 
         answer = json.loads(answer)
 
-        # if answer["status"] exists and is False, an error occured
+        # if answer["status"] exists and is False, an error occurred
         if not answer.get("status", True):
             self.output = {
                 "full_text": answer["error"],

--- a/i3pystatus/timer.py
+++ b/i3pystatus/timer.py
@@ -57,7 +57,7 @@ class Timer(IntervalModule):
     Two new event settings were added:
 
     - ``on_overflow`` - Executed when remaining time reaches zero.
-    - ``on_reset`` - Executed when timer is reset but only if overflow occured.
+    - ``on_reset`` - Executed when timer is reset but only if overflow occurred.
 
     These settings accept either a python callable object or a string with shell
     command.
@@ -159,9 +159,9 @@ class Timer(IntervalModule):
 
     def increase(self, seconds):
         """
-        Change remainig time value.
+        Change remaining time value.
 
-        :param int seconds: Seconds to add. Negative value substracts from
+        :param int seconds: Seconds to add. Negative value subtracts from
          remaining time.
         """
         if self.state is TimerState.running:
@@ -171,7 +171,7 @@ class Timer(IntervalModule):
 
     def reset(self):
         """
-        Stop timer and execute ``on_reset`` if overflow occured.
+        Stop timer and execute ``on_reset`` if overflow occurred.
         """
         if self.state is not TimerState.stopped:
             if self.on_reset and self.state is TimerState.overflow:


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- i3pystatus/calendar/google.py
- i3pystatus/coin.py
- i3pystatus/core/modules.py
- i3pystatus/ping.py
- i3pystatus/sabnzbd.py
- i3pystatus/timer.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `subtracts` rather than `substracts`.
- Should read `specify` rather than `specifiy`.
- Should read `remaining` rather than `remainig`.
- Should read `recommended` rather than `recomended`.
- Should read `property` rather than `propertie`.
- Should read `available` rather than `availible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md