### PR TITLE
i3pystatus.weather.wunderground: Fix regression in high temp

### DIFF
--- a/i3pystatus/weather/wunderground.py
+++ b/i3pystatus/weather/wunderground.py
@@ -201,6 +201,9 @@ class Wunderground(WeatherBackend):
                                     return default
                             else:
                                 return default
+
+                if ptr is None:
+                    return default
                 return str(ptr)
 
             pressure_tendency = _find(


### PR DESCRIPTION
In the afternoon this value becomes null. Set it to an empty string when
the null value is encountered.