### PR TITLE
Pass more mouse data from i3bar to modules

### DIFF
--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -38,8 +38,15 @@ class CommandEndpoint:
             button = cmd["button"]
             kwargs = {"button_id": button}
             try:
-                kwargs.update({"pos_x": cmd["x"],
-                               "pos_y": cmd["y"]})
+                kwargs.update({
+                    "pos_x": cmd["x"],
+                    "pos_y": cmd["y"],
+                    "modifiers": cmd.get("modifiers"),
+                    "relative_x": cmd.get("relative_x"),
+                    "relative_y": cmd.get("relative_y"),
+                    "width": cmd.get("width"),
+                    "height": cmd.get("height"),
+                })
             except Exception:
                 continue
 


### PR DESCRIPTION
Besides the current position relative to the screen, it is interesting to get
- modifiers (keys pressed while clicking)
- position relative to the module's block
- size of the module's block

This allows modules to add more interactivity options by combining clicks and keyboard, and figuring out precisely what was clicked in the module's block.
