### PR TITLE
i3pystatus.scores.mlb: Fix for zero scores being hidden in formatp blocks

### DIFF
--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -272,16 +272,19 @@ class MLB(ScoresBackend):
             ret[f'{team}_wins'] = self.get_nested(
                 team_data,
                 'leagueRecord:wins',
+                callback=self.zero_fallback,
                 default=0)
             ret[f'{team}_losses'] = self.get_nested(
                 team_data,
                 'leagueRecord:losses',
+                callback=self.zero_fallback,
                 default=0)
 
             ret[f'{team}_score'] = self.get_nested(
                 linescore,
                 f'teams:{team}:runs',
-                default='0')
+                callback=self.zero_fallback,
+                default=0)
 
         for key in ('delay', 'postponed', 'suspended'):
             ret[key] = ''


### PR DESCRIPTION
This fix was previously applied to the nhl and nba backends, but forgotten for mlb.