### PR TITLE
Fix default MPD time format

### DIFF
--- a/i3pystatus/mpd.py
+++ b/i3pystatus/mpd.py
@@ -97,7 +97,7 @@ cleartext to the server.)"),
     color_map = {}
     max_field_len = 25
     max_len = 100
-    time_format = "%M:MS"
+    time_format = "%m:%S"
     truncate_fields = ("title", "album", "artist", "album_artist")
     hide_inactive = False
     on_leftclick = "switch_playpause"


### PR DESCRIPTION
Change the default value of the `time_format` setting in the mpd module so that it matches the default value used by `TimeWrapper`.

This fixes a bug where the seconds were incorrectly displaying as `MS` by default due to a typo.

Before: `02:MS`
After: `2:06`

Reference: #819