### PR TITLE
i3pystatus.scores.mlb: Update default colors to reflect API change

### DIFF
--- a/i3pystatus/scores/mlb.py
+++ b/i3pystatus/scores/mlb.py
@@ -145,7 +145,7 @@ class MLB(ScoresBackend):
     required = ()
 
     _default_colors = {
-        'ARI': '#A71930',
+        'AZ': '#A71930',
         'ATL': '#CE1141',
         'BAL': '#DF4601',
         'BOS': '#BD3039',


### PR DESCRIPTION
The Arizona Diamondbacks are now identified using AZ instead of ARI.