### PR TITLE
Fix get_api_key() on wunderground.py

### DIFF
--- a/i3pystatus/weather/wunderground.py
+++ b/i3pystatus/weather/wunderground.py
@@ -110,8 +110,10 @@ class Wunderground(WeatherBackend):
             self.logger.exception(f'Failed to load {url}')
         else:
             try:
-                return re.search(r'apiKey=([0-9a-f]+)', page_source).group(1)
-            except AttributeError:
+                r = re.finditer(r'apiKey=([0-9a-f]+)', page_source)
+                next(r)
+                return next(r).group(1)
+            except (StopIteration, IndexError, AttributeError):
                 self.logger.error('Failed to find API key in mainpage source')
 
     @require(internet)


### PR DESCRIPTION
The first API key match in the main webpage stopped working for my weather requests.
I used the second one instead and it appear to be working.

I counted 10 matches of `api_key=([0-9a-f]+)` altogether in the source, the 1st and 4th being the same and which appear to be a developers' API key. The others are the same key which seems to work.
In my patch I used the second match using finditer() and next()
