### PR TITLE
core/__init__.py: Fix attribute check

### DIFF
--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -66,7 +66,7 @@ class Status:
     def __init__(self, standalone=True, click_events=True, interval=1,
                  input_stream=None, logfile=None, internet_check=None,
                  keep_alive=False, logformat=DEFAULT_LOG_FORMAT,
-                 default_hints=None):
+                 default_hints={}):
         self.standalone = standalone
         self.default_hints = default_hints
         self.click_events = standalone and click_events
@@ -113,7 +113,7 @@ class Status:
 
         # Merge the module's hints with the default hints
         # and overwrite any duplicates with the hint from the module
-        hints = self.default_hints.copy() if hasattr(self, "default_hints") else {}
+        hints = self.default_hints.copy()
         hints.update(kwargs.get('hints', {}))
         if hints:
             kwargs['hints'] = hints

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -113,7 +113,7 @@ class Status:
 
         # Merge the module's hints with the default hints
         # and overwrite any duplicates with the hint from the module
-        hints = self.default_hints.copy() if self.default_hints else {}
+        hints = self.default_hints.copy() if hasattr(self, "default_hints") else {}
         hints.update(kwargs.get('hints', {}))
         if hints:
             kwargs['hints'] = hints

--- a/i3pystatus/core/__init__.py
+++ b/i3pystatus/core/__init__.py
@@ -113,7 +113,7 @@ class Status:
 
         # Merge the module's hints with the default hints
         # and overwrite any duplicates with the hint from the module
-        hints = self.default_hints.copy()
+        hints = self.default_hints.copy() if hasattr(self, "default_hints") else {}
         hints.update(kwargs.get('hints', {}))
         if hints:
             kwargs['hints'] = hints


### PR DESCRIPTION
Addressing the issue of registering groups ( #854 ) I changed the following:

Use an empty dict as a default for `default_hints`
Use `hasattr()` instead of bare object access/check

When `default_hints` is passed to the `Status` object instanciation the following error  ` Fatal Error - ValueError(Additional arguments are invalid if 'module' is already an object)` is shown.

This can be handled by excluding type of `i3pystatus.group.Group` in the check at L118 but I could not  import the class due to:

```python
  File "/github/i3pystatus/venv/lib/python3.11/site-packages/i3pystatus/core/__init__.py", line 6, in <module>
    from i3pystatus.group import Group
  File "/github/i3pystatus/venv/lib/python3.11/site-packages/i3pystatus/group.py", line 1, in <module>
    from i3pystatus import IntervalModule, Status, Module
ImportError: cannot import name 'IntervalModule' from partially initialized module 'i3pystatus' (most likely due to a circular import) (/github/i3pystatus/venv/lib/python3.11/site-packages/i3pystatus/__init__.py)
```

I could fix all imports but the import of `Status` which also showed the above error