### PR TITLE
tests/test_buds: absolutify test file path

### DIFF
--- a/tests/test_buds.py
+++ b/tests/test_buds.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from copy import deepcopy
+from pathlib import Path
 from unittest.mock import patch
 from i3pystatus.core.color import ColorRangeModule
 from i3pystatus.buds import Buds, BudsEqualizer, BudsPlacementStatus
@@ -9,7 +10,7 @@ from i3pystatus.buds import Buds, BudsEqualizer, BudsPlacementStatus
 class TestBuds(unittest.TestCase):
     def setUp(self):
         self.buds = Buds()
-        with open('test_buds.json', 'rb') as file:
+        with (Path(__file__).parent / "test_buds.json").open('rb') as file:
             self.payload = json.load(file)
 
     @patch('i3pystatus.buds.run_through_shell')


### PR DESCRIPTION
I am working on updating the [package of this repo on Nixpkgs](https://github.com/NixOS/nixpkgs/pull/327430)
but I found a blocker around the test loading the test data as a relative path and this breaks because
the test script doesn't do the chdir to the test folder before running the test. This PR fixes this
and by merging  it I can enable the buds test without issues.

Signed-off-by: lucasew <lucas59356@gmail.com>
