### PR TITLE
Add element_call plugin to show active users on an Element Call bridge 

### DIFF
--- a/i3pystatus/element_call.py
+++ b/i3pystatus/element_call.py
@@ -1,0 +1,171 @@
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from i3pystatus import IntervalModule
+from i3pystatus.core.util import internet, require
+
+
+class ElementCall(IntervalModule):
+    """
+    Displays the number of active participants in an Element Call room on a
+    Matrix homeserver. Uses the Matrix Client-Server API to read
+    ``org.matrix.msc3401.call.member`` state events and counts members whose
+    session has not yet expired.
+
+    Requires a Matrix access token with read access to the target room.
+
+    .. rubric:: Available formatters
+
+    * ``{participants}`` — number of active call participants
+    * ``{room_id}`` — the Matrix room ID being monitored
+    * ``{room_alias}`` — the room_alias setting value
+
+    .. rubric:: Example configuration
+
+    .. code-block:: python
+
+        status.register(
+            "element_call",
+            homeserver="https://matrix.example.com",
+            access_token="syt_...",
+            room_id="!abc123:example.com",
+            format_active="\U0001F4DE {participants}",
+            format_empty="\U0001F4DE",
+            interval=15,
+        )
+    """
+
+    settings = (
+        ("homeserver", "Base URL of your Matrix homeserver (e.g. https://matrix.example.com)"),
+        ("access_token", "Matrix access token with read access to the room"),
+        ("room_id", "Matrix room ID to monitor (e.g. !abc123:example.com)"),
+        ("room_alias", "Human-readable label used in {room_alias} formatter"),
+        ("format_active", "Format string when participants > 0"),
+        ("format_empty", "Format string when no one is in the call"),
+        ("format_error", "Format string on API error"),
+        ("color_active", "Color when participants > 0"),
+        ("color_empty", "Color when call is empty"),
+        ("color_error", "Color on API error"),
+        ("interval", "Polling interval in seconds"),
+    )
+
+    homeserver = ""
+    access_token = ""
+    room_id = ""
+    room_alias = ""
+    format_active = "\U0001F4DE {participants}"
+    format_empty = ""
+    format_error = "\U0001F4DE ?"
+    color_active = "#00FF00"
+    color_empty = "#888888"
+    color_error = "#FF0000"
+    interval = 15
+
+    # MSC3401 state event type used by Element Call
+    _CALL_MEMBER_TYPE = "org.matrix.msc3401.call.member"
+
+    @require(internet)
+    def run(self):
+        try:
+            participants = self._count_participants()
+        except Exception:
+            self.output = {
+                "full_text": self.format_error,
+                "color": self.color_error,
+            }
+            return
+
+        fdict = {
+            "participants": participants,
+            "room_id": self.room_id,
+            "room_alias": self.room_alias,
+        }
+
+        if participants > 0:
+            self.output = {
+                "full_text": self.format_active.format(**fdict),
+                "color": self.color_active,
+            }
+        else:
+            self.output = {
+                "full_text": self.format_empty.format(**fdict),
+                "color": self.color_empty,
+            }
+
+    def _resolve_room_id(self, room_id_or_alias):
+        """Resolve a room alias (#name:server) to a room ID (!id:server) if needed."""
+        if room_id_or_alias.startswith("!"):
+            return room_id_or_alias
+        url = "{homeserver}/_matrix/client/v3/directory/room/{alias}".format(
+            homeserver=self.homeserver.rstrip("/"),
+            alias=urllib.parse.quote(room_id_or_alias, safe=""),
+        )
+        req = urllib.request.Request(
+            url,
+            headers={"Authorization": "Bearer {}".format(self.access_token)},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return data["room_id"]
+
+    def _count_participants(self):
+        """Return the number of active call participants in the room."""
+        resolved_id = self._resolve_room_id(self.room_id)
+        url = "{homeserver}/_matrix/client/v3/rooms/{room_id}/state".format(
+            homeserver=self.homeserver.rstrip("/"),
+            room_id=urllib.parse.quote(resolved_id, safe=""),
+        )
+        req = urllib.request.Request(
+            url,
+            headers={"Authorization": "Bearer {}".format(self.access_token)},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            state_events = json.loads(resp.read().decode("utf-8"))
+
+        now_ms = int(time.time() * 1000)
+        active_users = set()
+
+        for event in state_events:
+            if event.get("type") != self._CALL_MEMBER_TYPE:
+                continue
+
+            content = event.get("content", {})
+            if not content:
+                # Empty content means the member has left
+                continue
+
+            user_id = event.get("sender") or event.get("user_id", "")
+            state_key = event.get("state_key", "")
+
+            origin_ts = event.get("origin_server_ts", 0)
+
+            if state_key.startswith("@"):
+                # Per-user format: content has a "memberships" list
+                for membership in content.get("memberships", []):
+                    if self._membership_active(membership, now_ms, origin_ts):
+                        active_users.add(user_id)
+                        break
+            else:
+                # Per-device format: content itself is the membership object
+                if self._membership_active(content, now_ms, origin_ts):
+                    active_users.add(user_id)
+
+        return len(active_users)
+
+    def _membership_active(self, membership, now_ms, origin_ts=0):
+        """Return True if this membership entry has not yet expired."""
+        expires = membership.get("expires", 0)
+        if not expires:
+            return False
+        # Values > 1e12 are absolute epoch-ms timestamps.
+        # Smaller values are relative durations; anchor to created_ts, falling
+        # back to origin_server_ts from the event if created_ts is absent.
+        if expires > 1_000_000_000_000:
+            return expires > now_ms
+        created_ts = membership.get("created_ts") or origin_ts
+        return (created_ts + expires) > now_ms
+
+

--- a/i3pystatus/element_call.py
+++ b/i3pystatus/element_call.py
@@ -167,5 +167,3 @@ class ElementCall(IntervalModule):
             return expires > now_ms
         created_ts = membership.get("created_ts") or origin_ts
         return (created_ts + expires) > now_ms
-
-

--- a/tests/test_element_call.py
+++ b/tests/test_element_call.py
@@ -1,0 +1,241 @@
+import io
+import json
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from i3pystatus.element_call import ElementCall
+
+# Freeze time: 2026-04-21T00:00:00Z in milliseconds
+NOW_MS = 1_776_729_600_000
+
+ROOM_ALIAS = "#myroom:example.com"
+ROOM_ID = "!abc123:example.com"
+HOMESERVER = "https://matrix.example.com"
+ACCESS_TOKEN = "syt_test_token"
+
+
+def make_plugin(**kwargs):
+    ec = ElementCall.__new__(ElementCall)
+    ec.homeserver = HOMESERVER
+    ec.access_token = ACCESS_TOKEN
+    ec.room_id = kwargs.get("room_id", ROOM_ID)
+    ec.room_alias = kwargs.get("room_alias", "")
+    ec.format_active = kwargs.get("format_active", "\U0001F4DE {participants}")
+    ec.format_empty = kwargs.get("format_empty", "")
+    ec.format_error = kwargs.get("format_error", "\U0001F4DE ?")
+    ec.color_active = kwargs.get("color_active", "#00FF00")
+    ec.color_empty = kwargs.get("color_empty", "#888888")
+    ec.color_error = kwargs.get("color_error", "#FF0000")
+    return ec
+
+
+def urlopen_returning(payload):
+    """Return a mock context manager that yields a response with the given payload."""
+    body = json.dumps(payload).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def make_call_event(state_key, sender, content, origin_server_ts=NOW_MS):
+    return {
+        "type": "org.matrix.msc3401.call.member",
+        "state_key": state_key,
+        "sender": sender,
+        "content": content,
+        "origin_server_ts": origin_server_ts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _membership_active
+# ---------------------------------------------------------------------------
+
+class TestMembershipActive(unittest.TestCase):
+
+    def setUp(self):
+        self.ec = make_plugin()
+
+    def test_absolute_timestamp_future(self):
+        membership = {"expires": NOW_MS + 60_000}
+        self.assertTrue(self.ec._membership_active(membership, NOW_MS))
+
+    def test_absolute_timestamp_past(self):
+        membership = {"expires": NOW_MS - 1}
+        self.assertFalse(self.ec._membership_active(membership, NOW_MS))
+
+    def test_relative_duration_with_created_ts_active(self):
+        # created 1 hour ago, 4-hour duration → still active
+        created_ts = NOW_MS - 3_600_000
+        membership = {"expires": 14_400_000, "created_ts": created_ts}
+        self.assertTrue(self.ec._membership_active(membership, NOW_MS))
+
+    def test_relative_duration_with_created_ts_expired(self):
+        # created 5 hours ago, 4-hour duration → expired
+        created_ts = NOW_MS - 18_000_000
+        membership = {"expires": 14_400_000, "created_ts": created_ts}
+        self.assertFalse(self.ec._membership_active(membership, NOW_MS))
+
+    def test_relative_duration_falls_back_to_origin_ts(self):
+        # no created_ts; origin_ts is recent enough
+        origin_ts = NOW_MS - 3_600_000
+        membership = {"expires": 14_400_000}
+        self.assertTrue(self.ec._membership_active(membership, NOW_MS, origin_ts))
+
+    def test_relative_duration_origin_ts_expired(self):
+        # no created_ts; origin_ts is too old
+        origin_ts = NOW_MS - 18_000_000
+        membership = {"expires": 14_400_000}
+        self.assertFalse(self.ec._membership_active(membership, NOW_MS, origin_ts))
+
+    def test_zero_expires(self):
+        self.assertFalse(self.ec._membership_active({"expires": 0}, NOW_MS))
+
+    def test_missing_expires(self):
+        self.assertFalse(self.ec._membership_active({}, NOW_MS))
+
+
+# ---------------------------------------------------------------------------
+# _resolve_room_id
+# ---------------------------------------------------------------------------
+
+class TestResolveRoomId(unittest.TestCase):
+
+    def setUp(self):
+        self.ec = make_plugin()
+
+    def test_room_id_passthrough(self):
+        self.assertEqual(self.ec._resolve_room_id(ROOM_ID), ROOM_ID)
+
+    @patch("urllib.request.urlopen")
+    def test_alias_resolved(self, mock_urlopen):
+        mock_urlopen.return_value = urlopen_returning({"room_id": ROOM_ID, "servers": ["example.com"]})
+        result = self.ec._resolve_room_id(ROOM_ALIAS)
+        self.assertEqual(result, ROOM_ID)
+        url_used = mock_urlopen.call_args[0][0].full_url
+        self.assertIn("%23myroom%3Aexample.com", url_used)
+
+
+# ---------------------------------------------------------------------------
+# _count_participants
+# ---------------------------------------------------------------------------
+
+class TestCountParticipants(unittest.TestCase):
+
+    def setUp(self):
+        self.ec = make_plugin()
+
+    def _run_with_events(self, events):
+        with patch("urllib.request.urlopen") as mock_urlopen, \
+             patch("time.time", return_value=NOW_MS / 1000):
+            mock_urlopen.return_value = urlopen_returning(events)
+            return self.ec._count_participants()
+
+    def test_no_events(self):
+        self.assertEqual(self._run_with_events([]), 0)
+
+    def test_ignores_non_call_events(self):
+        events = [{"type": "m.room.member", "state_key": "@alice:example.com", "content": {"membership": "join"}}]
+        self.assertEqual(self._run_with_events(events), 0)
+
+    def test_empty_content_not_counted(self):
+        event = make_call_event("_@alice:example.com_DEV1_m.call", "@alice:example.com", {})
+        self.assertEqual(self._run_with_events([event]), 0)
+
+    def test_per_device_active(self):
+        content = {"expires": 14_400_000}
+        event = make_call_event(
+            "_@alice:example.com_DEV1_m.call", "@alice:example.com",
+            content, origin_server_ts=NOW_MS - 3_600_000,
+        )
+        self.assertEqual(self._run_with_events([event]), 1)
+
+    def test_per_device_expired(self):
+        content = {"expires": 14_400_000}
+        event = make_call_event(
+            "_@alice:example.com_DEV1_m.call", "@alice:example.com",
+            content, origin_server_ts=NOW_MS - 18_000_000,
+        )
+        self.assertEqual(self._run_with_events([event]), 0)
+
+    def test_per_user_format_active(self):
+        content = {"memberships": [{"expires": NOW_MS + 60_000}]}
+        event = make_call_event("@alice:example.com", "@alice:example.com", content)
+        self.assertEqual(self._run_with_events([event]), 1)
+
+    def test_per_user_format_expired(self):
+        content = {"memberships": [{"expires": NOW_MS - 1}]}
+        event = make_call_event("@alice:example.com", "@alice:example.com", content)
+        self.assertEqual(self._run_with_events([event]), 0)
+
+    def test_two_devices_same_user_counted_once(self):
+        content = {"expires": 14_400_000}
+        events = [
+            make_call_event("_@alice:example.com_DEV1_m.call", "@alice:example.com",
+                            content, origin_server_ts=NOW_MS - 3_600_000),
+            make_call_event("_@alice:example.com_DEV2_m.call", "@alice:example.com",
+                            content, origin_server_ts=NOW_MS - 3_600_000),
+        ]
+        self.assertEqual(self._run_with_events(events), 1)
+
+    def test_two_users_counted_separately(self):
+        content = {"expires": 14_400_000}
+        events = [
+            make_call_event("_@alice:example.com_DEV1_m.call", "@alice:example.com",
+                            content, origin_server_ts=NOW_MS - 3_600_000),
+            make_call_event("_@bob:example.com_DEV1_m.call", "@bob:example.com",
+                            content, origin_server_ts=NOW_MS - 3_600_000),
+        ]
+        self.assertEqual(self._run_with_events(events), 2)
+
+    def test_mixed_active_and_left(self):
+        active_content = {"expires": 14_400_000}
+        events = [
+            make_call_event("_@alice:example.com_DEV1_m.call", "@alice:example.com",
+                            active_content, origin_server_ts=NOW_MS - 3_600_000),
+            make_call_event("_@bob:example.com_DEV1_m.call", "@bob:example.com",
+                            {}, origin_server_ts=NOW_MS - 3_600_000),
+        ]
+        self.assertEqual(self._run_with_events(events), 1)
+
+
+# ---------------------------------------------------------------------------
+# run() — output formatting
+# ---------------------------------------------------------------------------
+
+class TestRun(unittest.TestCase):
+
+    def setUp(self):
+        self.ec = make_plugin()
+
+    def _run_with_count(self, count):
+        with patch.object(self.ec, "_count_participants", return_value=count):
+            self.ec.run()
+
+    def test_active_output(self):
+        self._run_with_count(2)
+        self.assertEqual(self.ec.output["full_text"], "\U0001F4DE 2")
+        self.assertEqual(self.ec.output["color"], "#00FF00")
+
+    def test_empty_output(self):
+        self._run_with_count(0)
+        self.assertEqual(self.ec.output["full_text"], "")
+        self.assertEqual(self.ec.output["color"], "#888888")
+
+    def test_error_output(self):
+        with patch.object(self.ec, "_count_participants", side_effect=Exception("boom")):
+            self.ec.run()
+        self.assertEqual(self.ec.output["full_text"], "\U0001F4DE ?")
+        self.assertEqual(self.ec.output["color"], "#FF0000")
+
+    def test_format_includes_room_alias(self):
+        ec = make_plugin(format_active="{room_alias}: {participants}", room_alias="Family")
+        with patch.object(ec, "_count_participants", return_value=3):
+            ec.run()
+        self.assertEqual(ec.output["full_text"], "Family: 3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_element_call.py
+++ b/tests/test_element_call.py
@@ -129,7 +129,7 @@ class TestCountParticipants(unittest.TestCase):
 
     def _run_with_events(self, events):
         with patch("urllib.request.urlopen") as mock_urlopen, \
-             patch("time.time", return_value=NOW_MS / 1000):
+                patch("time.time", return_value=NOW_MS / 1000):
             mock_urlopen.return_value = urlopen_returning(events)
             return self.ec._count_participants()
 


### PR DESCRIPTION
Adds a new IntervalModule that polls a Matrix homeserver and displays the number of users currently in an Element Call video/audio room.

Features:
  - Accepts either a room ID (!abc:server) or room alias (#name:server), resolving aliases automatically via the Matrix directory API
  - Handles both MSC3401 per-user (@user:server state key) and per-device (_@user_DEVICE_m.call state key) membership event formats
  - Deduplicates multi-device sessions so each user is counted once

Configuration example:
```
status.register(
      "element_call",
      homeserver="https://matrix.example.com",
      access_token="syt_...",
      room_id="#myroom:example.com",
      format_active="\U0001F4DE {participants}",
      format_empty="",
      interval=15,
  )
```